### PR TITLE
Suggest `tail -F` instead of `tail -f`

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -8,7 +8,7 @@ If you're using `skpm`, use `console.log` as usual.
 
 You can view the logs using `Console.app -> ~/Library/Logs -> com.bohemiancoding.sketch -> Plugin Output.log`, or in the terminal
 ```bash
-tail -f ~/Library/Logs/com.bohemiancoding.sketch3/Plugin\ Output.log
+tail -F ~/Library/Logs/com.bohemiancoding.sketch3/Plugin\ Output.log
 ```
 
 Occasionally this file disappears — in that case, run this and then try `tail`ing again.


### PR DESCRIPTION
from `man tail`:

> The -F option implies the -f option, but tail will also check to see if the file being followed has been renamed or rotated.  The file is closed and reopened when tail detects that the filename being read from has a new inode number.  The -F option is ignored if reading from standard input rather than a file.

Seems like good practice if sometimes the file vanishes and whatnot.

@jongold 