### PR TITLE
Symbol support

### DIFF
--- a/__tests__/components/RedBox.js
+++ b/__tests__/components/RedBox.js
@@ -13,4 +13,10 @@ describe('<RedBox />', () => {
       expect(tree).toMatchSnapshot();
     }
   });
+
+  it('renders string errors', () => {
+    const tree = renderer.create(<RedBox error={'String only error'} />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/__tests__/components/__snapshots__/RedBox.js.snap
+++ b/__tests__/components/__snapshots__/RedBox.js.snap
@@ -141,3 +141,31 @@ exports[`<RedBox /> renders simple errors 1`] = `
   </view>
 </view>
 `;
+
+exports[`<RedBox /> renders string errors 1`] = `
+<view
+  name="RedBox"
+  style={
+    Object {
+      "backgroundColor": "rgb(204, 0, 0)",
+      "paddingBottom": 10,
+      "paddingLeft": 10,
+      "paddingRight": 10,
+      "paddingTop": 10,
+      "width": 480,
+    }
+  }>
+  <text
+    name="Message"
+    style={
+      Object {
+        "color": "white",
+        "fontSize": 16,
+        "fontWeight": "bold",
+        "lineHeight": 19.2,
+      }
+    }>
+    Error: String only error
+  </text>
+</view>
+`;

--- a/__tests__/jsonUtils/layerGroup.js
+++ b/__tests__/jsonUtils/layerGroup.js
@@ -2,11 +2,12 @@ import layerGroup from '../../src/jsonUtils/layerGroup';
 
 describe('layer group', () => {
   it('is correctly constructed', () => {
-    const group = layerGroup(100, 200, 300, 400);
+    const group = layerGroup(100, 200, 300, 400, 0.5);
 
     expect(group).toHaveProperty('frame.x', 100);
     expect(group).toHaveProperty('frame.y', 200);
     expect(group).toHaveProperty('frame.width', 300);
     expect(group).toHaveProperty('frame.height', 400);
+    expect(group).toHaveProperty('style.contextSettings.opacity', 0.5);
   });
 });

--- a/__tests__/jsonUtils/models.js
+++ b/__tests__/jsonUtils/models.js
@@ -1,4 +1,11 @@
-import { generateID, makeColorFromCSS, makeColorFill, makeRect } from '../../src/jsonUtils/models';
+import {
+  generateID,
+  makeColorFromCSS,
+  makeColorFill,
+  makeRect,
+  makeSymbolInstance,
+  makeSymbolMaster,
+} from '../../src/jsonUtils/models';
 
 describe('generateID', () => {
   it('is unique', () => {
@@ -78,5 +85,31 @@ describe('makeRect', () => {
     expect(group).toHaveProperty('y', 200);
     expect(group).toHaveProperty('width', 300);
     expect(group).toHaveProperty('height', 400);
+  });
+});
+
+describe('makeSymbolInstance', () => {
+  it('is correctly constructed', () => {
+    const instance = makeSymbolInstance(
+      makeRect(0, 0, 100, 100),
+      'this is the symbol id',
+      'this is the name'
+    );
+
+    expect(instance).toHaveProperty('symbolID', 'this is the symbol id');
+    expect(instance).toHaveProperty('name', 'this is the name');
+  });
+});
+
+describe('makeSymbolMaster', () => {
+  it('is correctly constructed', () => {
+    const master = makeSymbolMaster(
+      makeRect(0, 0, 100, 100),
+      'this is the symbol id',
+      'this is the name'
+    );
+
+    expect(master).toHaveProperty('symbolID', 'this is the symbol id');
+    expect(master).toHaveProperty('name', 'this is the name');
   });
 });

--- a/__tests__/jsonUtils/shapeLayers.js
+++ b/__tests__/jsonUtils/shapeLayers.js
@@ -37,6 +37,7 @@ describe('makeRectShapeLayer', () => {
     expect(shapeLayer).toHaveProperty('frame.y', 200);
     expect(shapeLayer).toHaveProperty('frame.width', 300);
     expect(shapeLayer).toHaveProperty('frame.height', 400);
+    expect(shapeLayer).toHaveProperty('fixedRadius', 10);
   });
 });
 

--- a/__tests__/utils/compose.js
+++ b/__tests__/utils/compose.js
@@ -1,0 +1,10 @@
+import compose from '../../src/utils/compose';
+
+test('simple example', () => {
+  const toUpperCase = a => a.toUpperCase();
+  const slice = a => a.slice(0, 5);
+  const reverse = a => a.split('').reverse().join('');
+  const composed = compose(reverse, slice, toUpperCase);
+
+  expect(composed('hello world')).toEqual('OLLEH');
+});

--- a/docs/guides/data-fetching.md
+++ b/docs/guides/data-fetching.md
@@ -6,10 +6,7 @@ Pull real data from an API with `fetch` or GraphQL.
 
 [Full example](https://github.com/airbnb/react-sketchapp/tree/master/examples/foursquare-maps)
 
-First, add the [Sketch `fetch` polyfill](https://github.com/mathieudutour/sketch-module-fetch-polyfill) to your projects
-```
-npm install sketch-module-fetch-polyfill --save
-```
+`skpm` automatically provides the [Sketch `fetch` polyfill](https://github.com/mathieudutour/sketch-module-fetch-polyfill) — just use `fetch` as usual.
 
 ```js
 import fetch from 'sketch-module-fetch-polyfill'

--- a/examples/basic-setup/README.md
+++ b/examples/basic-setup/README.md
@@ -26,6 +26,6 @@ Then, open Sketch and navigate to `Plugins → react-sketchapp: Basic skpm Examp
 
 ## The idea behind the example
 
-Using skpm to build `react-sketchapp` apps requires a little bit of configuration - use this as an example.
+[`skpm`](https://github.com/sketch-pm/skpm) is the easiest way to build `react-sketchapp` projects - this is a minimal example of it in use.
 
 ![examples-basic](https://cloud.githubusercontent.com/assets/591643/24778192/1f0684ec-1ade-11e7-866b-b11bb60ac109.png)

--- a/examples/basic-setup/package.json
+++ b/examples/basic-setup/package.json
@@ -14,7 +14,7 @@
   "author": "Jon Gold <jon.gold@airbnb.com>",
   "license": "MIT",
   "devDependencies": {
-    "skpm": "^0.8.0"
+    "skpm": "^0.9.0"
   },
   "dependencies": {
     "chroma-js": "^1.2.2",

--- a/examples/basic-setup/src/my-command.js
+++ b/examples/basic-setup/src/my-command.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { render, Artboard, Text, View, Image, makeSymbol, injectSymbols } from 'react-sketchapp';
+import { render, Artboard, Text, View, Image, makeSymbol, injectSymbols, makeSymbolByName } from 'react-sketchapp';
 import chroma from 'chroma-js';
 
 // take a hex and give us a nice text color to put over it
@@ -44,12 +44,17 @@ const Color = {
   name: PropTypes.string.isRequired,
 };
 
+// const ImageSym = makeSymbol(() =>
+//   <Image
+//     source="https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg"
+//     name="myImage"
+//     style={{ width: 100, height: 100 }}
+//   />
+// );
 const ImageSym = makeSymbol(() =>
-  <Image
-    source="https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg"
-    name="myImage"
-    style={{ width: 100, height: 100 }}
-  />
+  <View style={{ widht: 100, height: 100 }}>
+    myImage
+  </View>
 );
 
 const OtherSymbol = makeSymbol(() =>
@@ -64,6 +69,8 @@ const OtherSymbol = makeSymbol(() =>
     hi
   </View>
 )
+
+// const SwatchHaus = makeSymbolByName('Swatch Haus')
 
 const NestedSymbolSymbol = makeSymbol(() =>
   <View

--- a/examples/basic-setup/src/my-command.js
+++ b/examples/basic-setup/src/my-command.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { render, Artboard, Text, View, Image, makeSymbol, injectSymbols, makeSymbolByName } from 'react-sketchapp';
+import { render, Artboard, Text, View } from 'react-sketchapp';
 import chroma from 'chroma-js';
 
 // take a hex and give us a nice text color to put over it
@@ -32,56 +32,12 @@ const Swatch = ({ name, hex }) => (
   </View>
 );
 
-Swatch.defaultProps = {
-  name: 'Name',
-  hex: '#000'
-}
-
-Swatch.propTypes = Color;
-
 const Color = {
   hex: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
 };
 
-// const ImageSym = makeSymbol(() =>
-//   <Image
-//     source="https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg"
-//     name="myImage"
-//     style={{ width: 100, height: 100 }}
-//   />
-// );
-const ImageSym = makeSymbol(() =>
-  <View style={{ widht: 100, height: 100 }}>
-    myImage
-  </View>
-);
-
-const OtherSymbol = makeSymbol(() =>
-  <View
-    name="A square"
-    style={{
-      height: 100,
-      width: 100,
-      backgroundColor: 'blue'
-    }}
-  >
-    hi
-  </View>
-)
-
-// const SwatchHaus = makeSymbolByName('Swatch Haus')
-
-const NestedSymbolSymbol = makeSymbol(() =>
-  <View
-    style={{
-      height: 104,
-      width: 104,
-    }}
-  >
-    <ImageSym name="A nested symbol" style={{ width: 100, height: 100 }} />
-  </View>
-)
+Swatch.propTypes = Color;
 
 const Document = ({ colors }) => (
   <Artboard
@@ -93,13 +49,6 @@ const Document = ({ colors }) => (
     }}
   >
     {Object.keys(colors).map(color => <Swatch name={color} hex={colors[color]} key={color} />)}
-    <NestedSymbolSymbol
-      style={{ width: 104, height: 104 }}
-      overrides={{
-        'A nested symbol': OtherSymbol,
-        hi: 'hello!'
-      }}
-    />
   </Artboard>
 );
 
@@ -108,8 +57,6 @@ Document.propTypes = {
 };
 
 export default (context) => {
-  injectSymbols(context);
-
   const colorList = {
     Haus: '#F3F4F4',
     Night: '#333',

--- a/examples/basic-setup/src/my-command.js
+++ b/examples/basic-setup/src/my-command.js
@@ -37,7 +37,12 @@ Swatch.defaultProps = {
   hex: '#000'
 }
 
-const SwatchSym = makeSymbol(Swatch);
+Swatch.propTypes = Color;
+
+const Color = {
+  hex: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+};
 
 const ImageSym = makeSymbol(() =>
   <Image
@@ -47,12 +52,29 @@ const ImageSym = makeSymbol(() =>
   />
 );
 
-const Color = {
-  hex: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
-};
+const OtherSymbol = makeSymbol(() =>
+  <View
+    name="A square"
+    style={{
+      height: 100,
+      width: 100,
+      backgroundColor: 'blue'
+    }}
+  >
+    hi
+  </View>
+)
 
-Swatch.propTypes = Color;
+const NestedSymbolSymbol = makeSymbol(() =>
+  <View
+    style={{
+      height: 104,
+      width: 104,
+    }}
+  >
+    <ImageSym name="A nested symbol" style={{ width: 100, height: 100 }} />
+  </View>
+)
 
 const Document = ({ colors }) => (
   <Artboard
@@ -64,8 +86,13 @@ const Document = ({ colors }) => (
     }}
   >
     {Object.keys(colors).map(color => <Swatch name={color} hex={colors[color]} key={color} />)}
-    <SwatchSym style={{ width: 104, height: 104 }} overrides={{ 'Name': 'Hello' }}/>
-    <ImageSym style={{ width: 100, height: 100 }} overrides={{ 'myImage': 'https://pbs.twimg.com/profile_images/833785170285178881/loBb32g3.jpg' }} />
+    <NestedSymbolSymbol
+      style={{ width: 104, height: 104 }}
+      overrides={{
+        'A nested symbol': OtherSymbol,
+        hi: 'hello!'
+      }}
+    />
   </Artboard>
 );
 

--- a/examples/basic-setup/src/my-command.js
+++ b/examples/basic-setup/src/my-command.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { render, Artboard, Text, View } from 'react-sketchapp';
+import { render, Artboard, Text, View, Image, makeSymbol, injectSymbols } from 'react-sketchapp';
 import chroma from 'chroma-js';
 
 // take a hex and give us a nice text color to put over it
@@ -32,6 +32,21 @@ const Swatch = ({ name, hex }) => (
   </View>
 );
 
+Swatch.defaultProps = {
+  name: 'Name',
+  hex: '#000'
+}
+
+const SwatchSym = makeSymbol(Swatch);
+
+const ImageSym = makeSymbol(() =>
+  <Image
+    source="https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg"
+    name="myImage"
+    style={{ width: 100, height: 100 }}
+  />
+);
+
 const Color = {
   hex: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
@@ -49,6 +64,8 @@ const Document = ({ colors }) => (
     }}
   >
     {Object.keys(colors).map(color => <Swatch name={color} hex={colors[color]} key={color} />)}
+    <SwatchSym style={{ width: 104, height: 104 }} overrides={{ 'Name': 'Hello' }}/>
+    <ImageSym style={{ width: 100, height: 100 }} overrides={{ 'myImage': 'https://pbs.twimg.com/profile_images/833785170285178881/loBb32g3.jpg' }} />
   </Artboard>
 );
 
@@ -57,6 +74,8 @@ Document.propTypes = {
 };
 
 export default (context) => {
+  injectSymbols(context);
+
   const colorList = {
     Haus: '#F3F4F4',
     Night: '#333',

--- a/examples/colors/package.json
+++ b/examples/colors/package.json
@@ -22,6 +22,6 @@
     "webpack-shell-plugin": "^0.5.0"
   },
   "devDependencies": {
-    "skpm": "^0.8.0"
+    "skpm": "^0.9.0"
   }
 }

--- a/examples/foursquare-maps/README.md
+++ b/examples/foursquare-maps/README.md
@@ -38,6 +38,6 @@ Open a browser to `http://localhost:3000`
 
 Creating maps with live data into Sketch is notoriously difficult — until now ;)
 
-This example is created with `react-primitives` and renders simultaneously to Sketch & Web, and polyfills `fetch` in Sketch with [`sketch-module-fetch-polyfill`](https://github.com/mathieudutour/sketch-module-fetch-polyfill) (automatically imported by `skpm`).
+This example is created with `react-primitives` and renders simultaneously to Sketch & Web — maps are provided by [react-primitives-google-static-map](https://www.npmjs.com/package/react-primitives-google-static-map).
 
 ![foursquare-maps](https://cloud.githubusercontent.com/assets/591643/25052095/f666928e-2104-11e7-805c-a3c73ffcabcb.png)

--- a/examples/foursquare-maps/README.md
+++ b/examples/foursquare-maps/README.md
@@ -38,6 +38,6 @@ Open a browser to `http://localhost:3000`
 
 Creating maps with live data into Sketch is notoriously difficult — until now ;)
 
-This example is created with `react-primitives` and renders simultaneously to Sketch & Web, and polyfills `fetch` in Sketch with [`sketch-module-fetch-polyfill`](https://github.com/mathieudutour/sketch-module-fetch-polyfill).
+This example is created with `react-primitives` and renders simultaneously to Sketch & Web, and polyfills `fetch` in Sketch with [`sketch-module-fetch-polyfill`](https://github.com/mathieudutour/sketch-module-fetch-polyfill) (automatically imported by `skpm`).
 
 ![foursquare-maps](https://cloud.githubusercontent.com/assets/591643/25052095/f666928e-2104-11e7-805c-a3c73ffcabcb.png)

--- a/examples/foursquare-maps/package.json
+++ b/examples/foursquare-maps/package.json
@@ -23,10 +23,9 @@
     "react-primitives": "^0.3.4",
     "react-primitives-google-static-map": "^1.0.1",
     "react-sketchapp": "^0.10.0",
-    "react-test-renderer": "^15.4.1",
-    "sketch-module-fetch-polyfill": "0.1.2"
+    "react-test-renderer": "^15.4.1"
   },
   "devDependencies": {
-    "skpm": "^0.8.0"
+    "skpm": "^0.9.0"
   }
 }

--- a/examples/foursquare-maps/src/getVenues.js
+++ b/examples/foursquare-maps/src/getVenues.js
@@ -1,6 +1,6 @@
 import param from 'jquery-param';
 
-export default (platformFetch) => {
+export default () => {
   const query = 'burger';
   const latitude = '37.773972';
   const longitude = '-122.431297';
@@ -15,7 +15,7 @@ export default (platformFetch) => {
     client_secret: 'Q10HUP5APBQOYNTPABSH4CSKRGEAI2CXIYULYGG0EZYUUWUZ',
   });
 
-  return platformFetch(`https://api.foursquare.com/v2/venues/search?${params}`)
+  return fetch(`https://api.foursquare.com/v2/venues/search?${params}`)
     .then(res => res.json())
     .then(data => ({
       venues: data.response.venues,

--- a/examples/foursquare-maps/src/main.js
+++ b/examples/foursquare-maps/src/main.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import fetch from 'sketch-module-fetch-polyfill';
 import { Artboard, render } from 'react-sketchapp';
 import App from './App';
 import getVenues from './getVenues';
 
 export default (context) => {
-  getVenues(fetch).then(({
+  getVenues().then(({
     venues,
     latitude,
     longitude,

--- a/examples/foursquare-maps/src/web.js
+++ b/examples/foursquare-maps/src/web.js
@@ -3,7 +3,7 @@ import { render } from 'react-dom';
 import App from './App';
 import getVenues from './getVenues';
 
-getVenues(fetch).then(({
+getVenues().then(({
   venues,
   latitude,
   longitude,

--- a/examples/profile-cards-graphql/package.json
+++ b/examples/profile-cards-graphql/package.json
@@ -16,10 +16,9 @@
     "gql-sketch": "^1.0.1",
     "react": "^15.4.2",
     "react-sketchapp": "^0.10.0",
-    "react-test-renderer": "^15.4.2",
-    "sketch-module-fetch-polyfill": "^0.1.3"
+    "react-test-renderer": "^15.4.2"
   },
   "devDependencies": {
-    "skpm": "^0.8.0"
+    "skpm": "^0.9.0"
   }
 }

--- a/examples/profile-cards-graphql/src/main.js
+++ b/examples/profile-cards-graphql/src/main.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, Text, View } from 'react-sketchapp';
 import Client from 'gql-sketch';
-import 'sketch-module-fetch-polyfill';
 import type { User } from './types';
 import { fonts, spacing } from './designSystem';
 import Profile from './components/Profile';

--- a/examples/profile-cards-primitives/package.json
+++ b/examples/profile-cards-primitives/package.json
@@ -23,6 +23,6 @@
     "react-test-renderer": "^15.4.1"
   },
   "devDependencies": {
-    "skpm": "^0.8.0"
+    "skpm": "^0.9.0"
   }
 }

--- a/examples/profile-cards-react-with-styles/package.json
+++ b/examples/profile-cards-react-with-styles/package.json
@@ -19,6 +19,6 @@
     "react-with-styles": "^1.4.0"
   },
   "devDependencies": {
-    "skpm": "^0.8.0"
+    "skpm": "^0.9.0"
   }
 }

--- a/examples/profile-cards/package.json
+++ b/examples/profile-cards/package.json
@@ -18,6 +18,6 @@
     "react-test-renderer": "^15.4.2"
   },
   "devDependencies": {
-    "skpm": "^0.8.0"
+    "skpm": "^0.9.0"
   }
 }

--- a/examples/styleguide/package.json
+++ b/examples/styleguide/package.json
@@ -19,6 +19,6 @@
     "react-test-renderer": "^15.4.2"
   },
   "devDependencies": {
-    "skpm": "^0.8.0"
+    "skpm": "^0.9.0"
   }
 }

--- a/examples/symbols/README.md
+++ b/examples/symbols/README.md
@@ -1,0 +1,31 @@
+# Basic setup
+
+## How to use
+Download the example or [clone the repo](http://github.com/airbnb/react-sketchapp):
+```
+curl https://codeload.github.com/airbnb/react-sketchapp/tar.gz/master | tar -xz --strip=2 react-sketchapp-master/examples/basic-setup
+cd basic-setup
+```
+
+Install the dependencies
+```
+npm install
+```
+
+Run with live reloading in Sketch
+```
+npm run render
+```
+
+Or, to install as a Sketch plugin:
+```
+npm run build
+npm run link-plugin
+```
+Then, open Sketch and navigate to `Plugins → react-sketchapp: Basic skpm Example`
+
+## The idea behind the example
+
+[`skpm`](https://github.com/sketch-pm/skpm) is the easiest way to build `react-sketchapp` projects - this is a minimal example of it in use.
+
+![examples-basic](https://cloud.githubusercontent.com/assets/591643/24778192/1f0684ec-1ade-11e7-866b-b11bb60ac109.png)

--- a/examples/symbols/README.md
+++ b/examples/symbols/README.md
@@ -22,7 +22,7 @@ Or, to install as a Sketch plugin:
 npm run build
 npm run link-plugin
 ```
-Then, open Sketch and navigate to `Plugins → react-sketchapp: Basic skpm Example`
+Then, open Sketch and navigate to `Plugins → react-sketchapp: Symbol Support`
 
 ## The idea behind the example
 

--- a/examples/symbols/README.md
+++ b/examples/symbols/README.md
@@ -1,10 +1,10 @@
-# Basic setup
+# Symbol Support
 
 ## How to use
 Download the example or [clone the repo](http://github.com/airbnb/react-sketchapp):
 ```
-curl https://codeload.github.com/airbnb/react-sketchapp/tar.gz/master | tar -xz --strip=2 react-sketchapp-master/examples/basic-setup
-cd basic-setup
+curl https://codeload.github.com/airbnb/react-sketchapp/tar.gz/master | tar -xz --strip=2 react-sketchapp-master/examples/symbols
+cd symbols
 ```
 
 Install the dependencies
@@ -27,5 +27,3 @@ Then, open Sketch and navigate to `Plugins → react-sketchapp: Basic skpm Examp
 ## The idea behind the example
 
 [`skpm`](https://github.com/sketch-pm/skpm) is the easiest way to build `react-sketchapp` projects - this is a minimal example of it in use.
-
-![examples-basic](https://cloud.githubusercontent.com/assets/591643/24778192/1f0684ec-1ade-11e7-866b-b11bb60ac109.png)

--- a/examples/symbols/package.json
+++ b/examples/symbols/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "symbols",
+  "version": "1.0.0",
+  "description": "",
+  "main": "symbols.sketchplugin",
+  "manifest": "src/manifest.json",
+  "scripts": {
+    "build": "skpm build",
+    "watch": "skpm build --watch",
+    "render": "skpm build --watch --run",
+    "render:once": "skpm build --run",
+    "link-plugin": "skpm link"
+  },
+  "author": "Jon Gold <jon.gold@airbnb.com>",
+  "license": "MIT",
+  "devDependencies": {
+    "skpm": "^0.9.0"
+  },
+  "dependencies": {
+    "chroma-js": "^1.2.2",
+    "prop-types": "^15.5.8",
+    "react": "^15.4.2",
+    "react-sketchapp": "^0.10.0",
+    "react-test-renderer": "^15.4.2"
+  }
+}

--- a/examples/symbols/src/manifest.json
+++ b/examples/symbols/src/manifest.json
@@ -1,0 +1,17 @@
+{
+	"compatibleVersion": 3,
+	"bundleVersion": 1,
+	"commands": [
+		{
+			"name": "react-sketchapp: Symbol Support",
+			"identifier": "main",
+			"script": "./my-command.js"
+		}
+	],
+	"menu": {
+		"isRoot": true,
+		"items": [
+			"main"
+		]
+	}
+}

--- a/examples/symbols/src/my-command.js
+++ b/examples/symbols/src/my-command.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { render, Artboard, Text, View, Image, makeSymbol, injectSymbols } from '../../../';
+import chroma from 'chroma-js';
+
+// take a hex and give us a nice text color to put over it
+const textColor = (hex) => {
+  const vsWhite = chroma.contrast(hex, 'white');
+  if (vsWhite > 4) {
+    return '#FFF';
+  }
+  return chroma(hex).darken(3).hex();
+};
+
+const RedSquare = () => (
+  <View name="Square" style={{ width: 100, height: 100, backgroundColor: 'red' }}>
+    Red Square
+  </View>
+);
+
+const RedSquareSym = makeSymbol(RedSquare);
+
+const BlueSquare = () => (
+  <View name="Square" style={{ width: 100, height: 100, backgroundColor: 'blue' }}>
+    Blue Square
+  </View>
+);
+
+const BlueSquareSym = makeSymbol(BlueSquare);
+
+const Photo = () => (
+  <Image
+    name="Photo"
+    source="https://pbs.twimg.com/profile_images/756488692135526400/JUCawBiW_400x400.jpg"
+    style={{ width: 100, height: 100 }}
+  />
+);
+
+const PhotoSym = makeSymbol(Photo);
+
+const Nested = () => (
+  <View name="Multi" style={{ display: 'flex', flexDirection: 'column', width: 75, height: 150 }}>
+    <PhotoSym name="Photo Instance" style={{ width: 75, height: 75 }} />
+    <RedSquareSym name="Red Square Instance" style={{ width: 75, height: 75 }} />
+  </View>
+)
+
+const NestedSym = makeSymbol(Nested);
+
+const Document = () => (
+  <Artboard name="Swatches" style={{ display: 'flex' }}>
+    <NestedSym
+      name="Nested Symbol"
+      style={{ width: 75, height: 150 }}
+      overrides={{
+        'Red Square Instance': BlueSquareSym,
+        'Blue Square': 'hello world',
+        Photo: 'https://pbs.twimg.com/profile_images/833785170285178881/loBb32g3.jpg'
+      }}
+    />
+  </Artboard>
+);
+
+
+export default (context) => {
+  injectSymbols(context);
+  render(<Document />, context.document.currentPage());
+}

--- a/examples/symbols/src/my-command.js
+++ b/examples/symbols/src/my-command.js
@@ -14,7 +14,9 @@ const textColor = (hex) => {
 
 const RedSquare = () => (
   <View name="Square" style={{ width: 100, height: 100, backgroundColor: 'red' }}>
-    Red Square
+    <Text name="Red Square Text">
+      Red Square
+    </Text>
   </View>
 );
 
@@ -22,7 +24,9 @@ const RedSquareSym = makeSymbol(RedSquare);
 
 const BlueSquare = () => (
   <View name="Square" style={{ width: 100, height: 100, backgroundColor: 'blue' }}>
-    Blue Square
+    <Text name="Blue Square Text">
+      Blue Square
+    </Text>
   </View>
 );
 
@@ -54,7 +58,7 @@ const Document = () => (
       style={{ width: 75, height: 150 }}
       overrides={{
         'Red Square Instance': BlueSquareSym,
-        'Blue Square': 'hello world',
+        'Blue Square Text': 'hello world',
         Photo: 'https://pbs.twimg.com/profile_images/833785170285178881/loBb32g3.jpg'
       }}
     />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sketchapp",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "A React renderer for Sketch.app",
   "main": "lib/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "normalize-css-color": "^1.0.1",
     "prop-types": "^15.5.8",
     "sketch-constants": "^1.0.2",
-    "sketchapp-json-flow-types": "git://github.com/lukewestby/sketchapp-json-flow-types.git#add_symbol_support",
+    "sketchapp-json-flow-types": "git://github.com/lukewestby/sketchapp-json-flow-types.git#address_5_comments",
     "sketchapp-json-plugin": "^0.0.3"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "normalize-css-color": "^1.0.1",
     "prop-types": "^15.5.8",
     "sketch-constants": "^1.0.2",
-    "sketchapp-json-flow-types": "^0.0.3",
+    "sketchapp-json-flow-types": "git://github.com/lukewestby/sketchapp-json-flow-types.git#add_symbol_support",
     "sketchapp-json-plugin": "^0.0.3"
   },
   "peerDependencies": {

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -3,7 +3,6 @@ import computeLayout from 'css-layout';
 import Context from './utils/Context';
 import createStringMeasurer from './utils/createStringMeasurer';
 import type { TreeNode } from './types';
-import { timeFunction } from './debug';
 import hasAnyDefined from './utils/hasAnyDefined';
 import pick from './utils/pick';
 
@@ -67,11 +66,8 @@ const reactTreeToFlexTree = (node: TreeNode, context: Context): TreeNode => {
 const buildTree = (element: React$Element<any>): TreeNode => {
   const renderer = TestRenderer.create(element);
   const json: TreeNode = renderer.toJSON();
-  const tree = timeFunction(
-    () => reactTreeToFlexTree(json, new Context()),
-    '- reactTreeToFlexTree',
-  );
-  timeFunction(() => computeLayout(tree), '- computeLayout');
+  const tree = reactTreeToFlexTree(json, new Context());
+  computeLayout(tree);
 
   return tree;
 };

--- a/src/components/RedBox.js
+++ b/src/components/RedBox.js
@@ -17,7 +17,7 @@ type StackFrame = {
   functionName?: string,
   source?: string,
   args?: any[],
-  evalOrigin?: StackFrame,
+  evalOrigin?: StackFrame
 };
 
 const styles = {
@@ -41,7 +41,7 @@ const styles = {
 };
 
 const propTypes = {
-  error: PropTypes.instanceOf(Error).isRequired,
+  error: PropTypes.oneOfType([PropTypes.instanceOf(Error), PropTypes.string]).isRequired,
   // filename: PropTypes.string,
   // editorScheme: PropTypes.string,
   // useLines: PropTypes.bool,
@@ -60,6 +60,14 @@ class RedBox extends React.Component {
 
   render() {
     const { error } = this.props;
+
+    if (typeof error === 'string') {
+      return (
+        <View name="RedBox" style={styles.redbox}>
+          <Text name="Message" style={styles.message}>{`Error: ${error}`}</Text>
+        </View>
+      );
+    }
 
     let frames;
     let parseError;

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import RedBox from './components/RedBox';
 import View from './components/View';
 import Text from './components/Text';
 import TextStyles from './sharedStyles/TextStyles';
-import Symbol from './symbol';
+import { makeSymbol, injectSymbols } from './symbol';
 
 module.exports = {
   render,
@@ -21,5 +21,6 @@ module.exports = {
   TextStyles,
   View,
   Platform,
-  Symbol,
+  makeSymbol,
+  injectSymbols,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import RedBox from './components/RedBox';
 import View from './components/View';
 import Text from './components/Text';
 import TextStyles from './sharedStyles/TextStyles';
+import Symbol from './symbol';
 
 module.exports = {
   render,
@@ -20,4 +21,5 @@ module.exports = {
   TextStyles,
   View,
   Platform,
+  Symbol,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import RedBox from './components/RedBox';
 import View from './components/View';
 import Text from './components/Text';
 import TextStyles from './sharedStyles/TextStyles';
-import { makeSymbol, injectSymbols } from './symbol';
+import { makeSymbol, injectSymbols, makeSymbolByName } from './symbol';
 
 module.exports = {
   render,
@@ -23,4 +23,5 @@ module.exports = {
   Platform,
   makeSymbol,
   injectSymbols,
+  makeSymbolByName,
 };

--- a/src/jsonUtils/layerGroup.js
+++ b/src/jsonUtils/layerGroup.js
@@ -2,7 +2,7 @@
 
 import { generateID, makeRect } from './models';
 
-const layerGroup = (x: number, y: number, width: number, height: number) => ({
+const layerGroup = (x: number, y: number, width: number, height: number, opacity: number) => ({
   _class: 'group',
   do_objectID: generateID(),
   exportOptions: {
@@ -28,6 +28,11 @@ const layerGroup = (x: number, y: number, width: number, height: number) => ({
     endDecorationType: 0,
     miterLimit: 10,
     startDecorationType: 0,
+    contextSettings: {
+      _class: 'graphicsContextSettings',
+      blendMode: 0,
+      opacity,
+    },
   },
   hasClickThrough: false,
   layers: [],

--- a/src/jsonUtils/models.js
+++ b/src/jsonUtils/models.js
@@ -1,6 +1,13 @@
 /* eslint-disable no-mixed-operators, no-bitwise */
 /* @flow */
-import type { SJColor, SJFill, SJImageDataReference, SJRect } from 'sketchapp-json-flow-types';
+import type {
+  SJColor,
+  SJFill,
+  SJImageDataReference,
+  SJRect,
+  SJSymbolMaster,
+  SJSymbolInstanceLayer,
+} from 'sketchapp-json-flow-types';
 import { FillType } from 'sketch-constants';
 import normalizeColor from 'normalize-css-color';
 import type { Color } from '../types';
@@ -81,7 +88,28 @@ export const makeRect = (x: number, y: number, width: number, height: number): S
   height,
 });
 
-export const makeSymbolInstance = (frame: SJRect, symbolID: string, name: string) => ({
+export const makeJSONDataReference = (image: MSImageData): SJImageDataReference => ({
+  _class: 'MSJSONOriginalDataReference',
+  _ref: `images/${generateID()}`,
+  _ref_class: 'MSImageData',
+  data: {
+    _data: image
+      .data()
+      .base64EncodedStringWithOptions(NSDataBase64EncodingEndLineWithCarriageReturn),
+    // TODO(gold): can I just declare this as a var instead of using Cocoa?
+  },
+  sha1: {
+    _data: image
+      .sha1()
+      .base64EncodedStringWithOptions(NSDataBase64EncodingEndLineWithCarriageReturn),
+  },
+});
+
+export const makeSymbolInstance = (
+  frame: SJRect,
+  symbolID: string,
+  name: string
+): SJSymbolInstanceLayer => ({
   _class: 'symbolInstance',
   horizontalSpacing: 0,
   verticalSpacing: 0,
@@ -93,7 +121,11 @@ export const makeSymbolInstance = (frame: SJRect, symbolID: string, name: string
   frame,
 });
 
-export const makeSymbolMaster = (frame: SJRect, symbolID: string, name: string) => ({
+export const makeSymbolMaster = (
+  frame: SJRect,
+  symbolID: string,
+  name: string
+): SJSymbolMaster => ({
   _class: 'symbolMaster',
   do_objectID: generateID(),
   nameIsFixed: true,

--- a/src/jsonUtils/models.js
+++ b/src/jsonUtils/models.js
@@ -11,11 +11,11 @@ for (let i = 0; i < 256; i += 1) {
 }
 // Hack (http://stackoverflow.com/a/21963136)
 function e7() {
-  const d0 = Math.random() * 0xffffffff | 0;
-  const d1 = Math.random() * 0xffffffff | 0;
-  const d2 = Math.random() * 0xffffffff | 0;
-  const d3 = Math.random() * 0xffffffff | 0;
-  return `${lut[d0 & 0xff] + lut[d0 >> 8 & 0xff] + lut[d0 >> 16 & 0xff] + lut[d0 >> 24 & 0xff]}-${lut[d1 & 0xff]}${lut[d1 >> 8 & 0xff]}-${lut[d1 >> 16 & 0x0f | 0x40]}${lut[d1 >> 24 & 0xff]}-${lut[d2 & 0x3f | 0x80]}${lut[d2 >> 8 & 0xff]}-${lut[d2 >> 16 & 0xff]}${lut[d2 >> 24 & 0xff]}${lut[d3 & 0xff]}${lut[d3 >> 8 & 0xff]}${lut[d3 >> 16 & 0xff]}${lut[d3 >> 24 & 0xff]}`;
+  const d0 = (Math.random() * 0xffffffff) | 0;
+  const d1 = (Math.random() * 0xffffffff) | 0;
+  const d2 = (Math.random() * 0xffffffff) | 0;
+  const d3 = (Math.random() * 0xffffffff) | 0;
+  return `${lut[d0 & 0xff] + lut[(d0 >> 8) & 0xff] + lut[(d0 >> 16) & 0xff] + lut[(d0 >> 24) & 0xff]}-${lut[d1 & 0xff]}${lut[(d1 >> 8) & 0xff]}-${lut[((d1 >> 16) & 0x0f) | 0x40]}${lut[(d1 >> 24) & 0xff]}-${lut[(d2 & 0x3f) | 0x80]}${lut[(d2 >> 8) & 0xff]}-${lut[(d2 >> 16) & 0xff]}${lut[(d2 >> 24) & 0xff]}${lut[d3 & 0xff]}${lut[(d3 >> 8) & 0xff]}${lut[(d3 >> 16) & 0xff]}${lut[(d3 >> 24) & 0xff]}`;
 }
 
 export function generateID(): string {
@@ -59,7 +59,7 @@ export const makeColorFill = (cssColor: Color): SJFill => ({
 
 export const makeImageFill = (
   image: SJImageDataReference,
-  patternFillType: 0 | 1 | 2 | 3 = 1,
+  patternFillType: 0 | 1 | 2 | 3 = 1
 ): SJFill => ({
   _class: 'fill',
   isEnabled: true,
@@ -79,4 +79,28 @@ export const makeRect = (x: number, y: number, width: number, height: number): S
   y,
   width,
   height,
+});
+
+export const makeSymbolInstance = (frame: SJRect, symbolID: string, name: string) => ({
+  _class: 'symbolInstance',
+  horizontalSpacing: 0,
+  verticalSpacing: 0,
+  nameIsFixed: true,
+  isVisible: true,
+  do_objectID: generateID(),
+  name,
+  symbolID,
+  frame,
+});
+
+export const makeSymbolMaster = (frame: SJRect, symbolID: string, name: string) => ({
+  _class: 'symbolMaster',
+  do_objectID: generateID(),
+  nameIsFixed: true,
+  isVisible: true,
+  backgroundColor: makeColorFromCSS('white'),
+  hasBackgroundColor: false,
+  name,
+  symbolID,
+  frame,
 });

--- a/src/jsonUtils/shapeLayers.js
+++ b/src/jsonUtils/shapeLayers.js
@@ -133,26 +133,29 @@ export const makeRectShapeLayer = (
   width: number,
   height: number,
   radii: Radii = [0, 0, 0, 0],
-) => ({
-  _class: 'rectangle',
-  do_objectID: generateID(),
-  frame: makeRect(x, y, width, height),
-  isFlippedHorizontal: false,
-  isFlippedVertical: false,
-  isLocked: false,
-  isVisible: true,
-  layerListExpandedType: 0,
-  name: 'Path',
-  nameIsFixed: false,
-  resizingType: 0,
-  rotation: 0,
-  shouldBreakMaskChain: false,
-  booleanOperation: -1,
-  edited: false,
-  path: makeRectPath(radii),
-  fixedRadius: 8,
-  hasConvertedToNewRoundCorners: true,
-});
+) => {
+  const fixedRadius = radii[0] || 0;
+  return {
+    _class: 'rectangle',
+    do_objectID: generateID(),
+    frame: makeRect(x, y, width, height),
+    isFlippedHorizontal: false,
+    isFlippedVertical: false,
+    isLocked: false,
+    isVisible: true,
+    layerListExpandedType: 0,
+    name: 'Path',
+    nameIsFixed: false,
+    resizingType: 0,
+    rotation: 0,
+    shouldBreakMaskChain: false,
+    booleanOperation: -1,
+    edited: false,
+    path: makeRectPath(radii),
+    fixedRadius,
+    hasConvertedToNewRoundCorners: true,
+  };
+};
 
 export const makeShapeGroup = (
   frame: SJRect,

--- a/src/render.js
+++ b/src/render.js
@@ -3,13 +3,12 @@ import type { SJLayer } from 'sketchapp-json-flow-types';
 import { appVersionSupported, fromSJSONDictionary } from 'sketchapp-json-plugin';
 import buildTree from './buildTree';
 import flexToSketchJSON from './flexToSketchJSON';
-import { timeFunction } from './debug';
 
 import type { SketchLayer, TreeNode } from './types';
 import RedBox from './components/RedBox';
 
 export const renderToJSON = (element: React$Element<any>): SJLayer => {
-  const tree = timeFunction(() => buildTree(element), 'build tree');
+  const tree = buildTree(element);
   return flexToSketchJSON(tree);
 };
 
@@ -23,11 +22,11 @@ const renderToSketch = (node: TreeNode, container: SketchLayer): SketchLayer => 
 export const render = (element: React$Element<any>, container: SketchLayer): ?SketchLayer => {
   if (appVersionSupported()) {
     try {
-      const tree = timeFunction(() => buildTree(element), 'build tree');
-      return timeFunction(() => renderToSketch(tree, container), 'new renderer');
+      const tree = buildTree(element);
+      return renderToSketch(tree, container);
     } catch (err) {
       const tree = buildTree(<RedBox error={err} />);
-      return timeFunction(() => renderToSketch(tree, container), 'new renderer');
+      return renderToSketch(tree, container);
     }
   }
   return null;

--- a/src/renderers/ImageRenderer.js
+++ b/src/renderers/ImageRenderer.js
@@ -1,5 +1,5 @@
 /* @flow */
-import type { SJShapeGroupLayer, SJImageDataReference } from 'sketchapp-json-flow-types';
+import type { SJShapeGroupLayer } from 'sketchapp-json-flow-types';
 import { BorderPosition } from 'sketch-constants';
 import { PatternFillType } from '../utils/constants';
 import SketchRenderer from './SketchRenderer';
@@ -10,7 +10,7 @@ import {
   makeColorFromCSS,
   makeColorFill,
   makeImageFill,
-  generateID,
+  makeJSONDataReference,
 } from '../jsonUtils/models';
 import { makeRectShapeLayer, makeShapeGroup } from '../jsonUtils/shapeLayers';
 import {
@@ -36,23 +36,6 @@ function extractURLFromSource(source) {
   return source.uri;
 }
 
-const makeJSONDataReference = (image): SJImageDataReference => ({
-  _class: 'MSJSONOriginalDataReference',
-  _ref: `images/${generateID()}`,
-  _ref_class: 'MSImageData',
-  data: {
-    _data: image
-      .data()
-      .base64EncodedStringWithOptions(NSDataBase64EncodingEndLineWithCarriageReturn),
-    // TODO(gold): can I just declare this as a var instead of using Cocoa?
-  },
-  sha1: {
-    _data: image
-      .sha1()
-      .base64EncodedStringWithOptions(NSDataBase64EncodingEndLineWithCarriageReturn),
-  },
-});
-
 class ImageRenderer extends SketchRenderer {
   renderBackingLayers(
     layout: LayoutInfo,
@@ -60,7 +43,7 @@ class ImageRenderer extends SketchRenderer {
     textStyle: TextStyle,
     props: any,
     // eslint-disable-next-line no-unused-vars
-    value: ?string,
+    value: ?string
   ): Array<SJShapeGroupLayer> {
     const layers = [];
 
@@ -160,7 +143,7 @@ class ImageRenderer extends SketchRenderer {
           0,
           layout.height,
           borderRightWidth,
-          borderRightColor,
+          borderRightColor
         );
         rightBorder.name = 'Border (right)';
 
@@ -178,7 +161,7 @@ class ImageRenderer extends SketchRenderer {
           layout.height - borderBottomWidth,
           layout.width,
           borderBottomWidth,
-          borderBottomColor,
+          borderBottomColor
         );
         bottomBorder.name = 'Border (bottom)';
 
@@ -196,7 +179,7 @@ class ImageRenderer extends SketchRenderer {
           0,
           layout.height,
           borderLeftWidth,
-          borderLeftColor,
+          borderLeftColor
         );
         leftBorder.name = 'Border (left)';
 

--- a/src/renderers/SketchRenderer.js
+++ b/src/renderers/SketchRenderer.js
@@ -24,7 +24,7 @@ class SketchRenderer {
     //   processTransform(layer, layout, style.transform);
     // }
 
-    const opacity = style.opacity || DEFAULT_OPACITY;
+    const opacity = style.opacity !== undefined ? style.opacity : DEFAULT_OPACITY;
 
     return {
       ...layerGroup(layout.left, layout.top, layout.width, layout.height, opacity),

--- a/src/renderers/SketchRenderer.js
+++ b/src/renderers/SketchRenderer.js
@@ -3,6 +3,8 @@ import layerGroup from '../jsonUtils/layerGroup';
 
 import type { LayoutInfo, ViewStyle, TextStyle, SketchJSON } from '../types';
 
+const DEFAULT_OPACITY = 1.0;
+
 class SketchRenderer {
   getDefaultGroupName(/* props: any, value: ?string */) {
     return 'Group';
@@ -13,7 +15,7 @@ class SketchRenderer {
     textStyle: TextStyle,
     props: any,
     // eslint-disable-next-line no-unused-vars
-    value: ?string,
+    value: ?string
   ): SketchJSON {
     // Default SketchRenderer just renders an empty group
 
@@ -22,13 +24,10 @@ class SketchRenderer {
     //   processTransform(layer, layout, style.transform);
     // }
 
-    // TODO(akp): handle opacity #sketch43
-    // if (style.opacity !== undefined) {
-    //   layer.style().contextSettings().opacity = style.opacity;
-    // }
+    const opacity = style.opacity || DEFAULT_OPACITY;
 
     return {
-      ...layerGroup(layout.left, layout.top, layout.width, layout.height),
+      ...layerGroup(layout.left, layout.top, layout.width, layout.height, opacity),
       name: props.name || this.getDefaultGroupName(props, value),
     };
   }
@@ -38,7 +37,7 @@ class SketchRenderer {
     textStyle: TextStyle,
     props: any,
     // eslint-disable-next-line no-unused-vars
-    value: ?string,
+    value: ?string
   ): Array<SketchJSON> {
     return [];
   }

--- a/src/renderers/SymbolInstanceRenderer.js
+++ b/src/renderers/SymbolInstanceRenderer.js
@@ -105,8 +105,6 @@ class SymbolInstanceRenderer extends SketchRenderer {
           const originalMaster = getSymbolMasterById(reference.symbolId);
           const replacementMaster = getSymbolMasterByName(overrideValue.masterName);
 
-          console.log(originalMaster);
-
           if (
             originalMaster.frame.width !== replacementMaster.frame.width ||
             originalMaster.frame.height !== replacementMaster.frame.height
@@ -123,7 +121,7 @@ class SymbolInstanceRenderer extends SketchRenderer {
           return {
             ...memo,
             [reference.objectId]: {
-              symbolID: overrideValue.symbolId,
+              symbolID: replacementMaster.symbolID,
               ...nestedOverrides,
             },
           };
@@ -165,6 +163,8 @@ class SymbolInstanceRenderer extends SketchRenderer {
 
       return memo;
     }, {});
+
+    console.log(overrides[Object.keys(overrides)[1]]);
 
     symbolInstance.overrides = {};
     symbolInstance.overrides['0'] = overrides;

--- a/src/renderers/SymbolInstanceRenderer.js
+++ b/src/renderers/SymbolInstanceRenderer.js
@@ -1,0 +1,24 @@
+/* @flow */
+import type { SJSymbolInstanceLayer } from 'sketchapp-json-flow-types';
+import SketchRenderer from './SketchRenderer';
+import { makeSymbolInstance, makeRect } from '../jsonUtils/models';
+import type { ViewStyle, LayoutInfo, TextStyle } from '../types';
+
+class SymbolInstanceRenderer extends SketchRenderer {
+  renderGroupLayer(
+    layout: LayoutInfo,
+    style: ViewStyle,
+    textStyle: TextStyle,
+    props: any,
+    // eslint-disable-next-line no-unused-vars
+    value: ?string
+  ): SJSymbolInstanceLayer {
+    return makeSymbolInstance(
+      makeRect(layout.left, layout.top, layout.width, layout.height),
+      props.symbolID,
+      props.name
+    );
+  }
+}
+
+module.exports = SymbolInstanceRenderer;

--- a/src/renderers/SymbolInstanceRenderer.js
+++ b/src/renderers/SymbolInstanceRenderer.js
@@ -3,7 +3,7 @@ import type { SJSymbolInstanceLayer, SJLayer, SJObjectId } from 'sketchapp-json-
 import SketchRenderer from './SketchRenderer';
 import { makeSymbolInstance, makeRect, makeJSONDataReference } from '../jsonUtils/models';
 import type { ViewStyle, LayoutInfo, TextStyle } from '../types';
-import { getMasterByName, getMasterBySymbolId } from '../symbol';
+import { getMasterBySymbolId } from '../symbol';
 import { makeImageDataFromUrl } from '../jsonUtils/hacksForJSONImpl';
 
 type OverrideReferenceBase = {
@@ -87,17 +87,13 @@ class SymbolInstanceRenderer extends SketchRenderer {
       return symbolInstance;
     }
 
-    const masterTree = getMasterByName(props.name);
-    if (!masterTree) {
-      throw new Error('##FIXME### NO MASTER BY THAT NAME');
-    }
-
+    const masterTree = getMasterBySymbolId(props.symbolID);
     const overridableLayers = extractOverrides(masterTree.layers);
 
     const overrides = overridableLayers.reduce(function inject(memo, reference) {
       if (reference.type === 'symbolInstance') {
+        // eslint-disable-next-line
         if (props.overrides.hasOwnProperty(reference.name)) {
-          // eslint-disable-line
           const overrideValue = props.overrides[reference.name];
           if (typeof overrideValue !== 'function' || typeof overrideValue.symbolId !== 'string') {
             throw new Error(
@@ -140,8 +136,8 @@ class SymbolInstanceRenderer extends SketchRenderer {
         };
       }
 
+      // eslint-disable-next-line
       if (!props.overrides.hasOwnProperty(reference.name)) {
-        // eslint-disable-line
         return memo;
       }
 

--- a/src/renderers/SymbolInstanceRenderer.js
+++ b/src/renderers/SymbolInstanceRenderer.js
@@ -1,8 +1,55 @@
 /* @flow */
-import type { SJSymbolInstanceLayer } from 'sketchapp-json-flow-types';
+import type { SJSymbolInstanceLayer, SJLayer, SJObjectId } from 'sketchapp-json-flow-types';
 import SketchRenderer from './SketchRenderer';
-import { makeSymbolInstance, makeRect } from '../jsonUtils/models';
+import { makeSymbolInstance, makeRect, makeJSONDataReference } from '../jsonUtils/models';
 import type { ViewStyle, LayoutInfo, TextStyle } from '../types';
+import { getMasterByName } from '../symbol';
+import { makeImageDataFromUrl } from '../jsonUtils/hacksForJSONImpl';
+
+type OverrideReferenceBase = {
+  objectId: SJObjectId,
+  name: string
+};
+
+type OverrideReference =
+  | ({ type: 'text' } & OverrideReferenceBase)
+  | ({ type: 'image' } & OverrideReferenceBase);
+
+const extractOverridesHelp = (subLayer: SJLayer, output: Array<OverrideReference>) => {
+  if (subLayer._class === 'text') {
+    output.push({ type: 'text', objectId: subLayer.do_objectID, name: subLayer.name });
+    return;
+  }
+
+  if (subLayer._class === 'group') {
+    if (subLayer.layers && subLayer.layers.length) {
+      const shapeGroup = subLayer.layers.find(l => l._class === 'shapeGroup');
+      if (
+        shapeGroup &&
+        shapeGroup._class === 'shapeGroup' &&
+        shapeGroup.style &&
+        shapeGroup.style.fills.some(f => f.image)
+      ) {
+        output.push({ type: 'image', objectId: shapeGroup.do_objectID, name: subLayer.name });
+      }
+    }
+  }
+
+  if (
+    (subLayer._class === 'shapeGroup' ||
+      subLayer._class === 'artboard' ||
+      subLayer._class === 'group') &&
+    subLayer.layers
+  ) {
+    subLayer.layers.forEach(subSubLayer => extractOverridesHelp(subSubLayer, output));
+  }
+};
+
+const extractOverrides = (subLayers: Array<SJLayer>): Array<OverrideReference> => {
+  const output = [];
+  subLayers.forEach(subLayer => extractOverridesHelp(subLayer, output));
+  return output;
+};
 
 class SymbolInstanceRenderer extends SketchRenderer {
   renderGroupLayer(
@@ -13,11 +60,55 @@ class SymbolInstanceRenderer extends SketchRenderer {
     // eslint-disable-next-line no-unused-vars
     value: ?string
   ): SJSymbolInstanceLayer {
-    return makeSymbolInstance(
+    const symbolInstance = makeSymbolInstance(
       makeRect(layout.left, layout.top, layout.width, layout.height),
       props.symbolID,
       props.name
     );
+
+    if (!props.overrides) {
+      return symbolInstance;
+    }
+
+    const masterTree = getMasterByName(props.name);
+    if (!masterTree) {
+      throw new Error('##FIXME### NO MASTER BY THAT NAME');
+    }
+
+    const overridableLayers = extractOverrides(masterTree.layers);
+    console.log(overridableLayers);
+
+    const overrides = Object.keys(props.overrides).reduce((memo, next) => {
+      const overrideKey = next;
+      const overrideValue = props.overrides[next];
+
+      const reference = overridableLayers.find(l => l.name === overrideKey);
+      if (!reference) {
+        throw new Error('##FIXME## TRIED TO OVERRIDE NON-EXISTENT LAYER');
+      }
+
+      if (reference.type === 'text') {
+        if (typeof overrideValue !== 'string') {
+          throw new Error('##FIXME## TEXT OVERRIDE VALUES MUST BE STRINGS');
+        }
+        return { ...memo, [reference.objectId]: overrideValue };
+      } else if (reference.type === 'image') {
+        if (typeof overrideValue !== 'string') {
+          throw new Error('##FIXME"" IMAGE OVERRIDE VALUES MUST BE VALID IMAGE HREFS');
+        }
+        return {
+          ...memo,
+          [reference.objectId]: makeJSONDataReference(makeImageDataFromUrl(overrideValue)),
+        };
+      }
+
+      return memo;
+    }, {});
+
+    symbolInstance.overrides = {};
+    symbolInstance.overrides['0'] = overrides;
+
+    return symbolInstance;
   }
 }
 

--- a/src/renderers/SymbolMasterRenderer.js
+++ b/src/renderers/SymbolMasterRenderer.js
@@ -1,0 +1,24 @@
+/* @flow */
+import type { SJSymbolMaster } from 'sketchapp-json-flow-types';
+import { makeSymbolMaster, makeRect } from '../jsonUtils/models';
+import SketchRenderer from './SketchRenderer';
+import type { ViewStyle, LayoutInfo, TextStyle } from '../types';
+
+class SymbolMasterRenderer extends SketchRenderer {
+  renderGroupLayer(
+    layout: LayoutInfo,
+    style: ViewStyle,
+    textStyle: TextStyle,
+    props: any,
+    // eslint-disable-next-line no-unused-vars
+    value: ?string
+  ): SJSymbolMaster {
+    return makeSymbolMaster(
+      makeRect(layout.top, layout.left, layout.width, layout.height),
+      props.symbolID,
+      props.name
+    );
+  }
+}
+
+module.exports = SymbolMasterRenderer;

--- a/src/renderers/index.js
+++ b/src/renderers/index.js
@@ -7,6 +7,8 @@ const renderers: { [key: string]: any } = {
   image: require('./ImageRenderer'),
   text: require('./TextRenderer'),
   view: require('./ViewRenderer'),
+  symbolinstance: require('./SymbolInstanceRenderer'),
+  symbolmaster: require('./SymbolMasterRenderer'),
 };
 
 module.exports = renderers;

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { fromSJSONDictionary } from 'sketchapp-json-plugin';
+import StyleSheet from './stylesheet';
+import { generateID } from './jsonUtils/models';
+import ViewStylePropTypes from './components/ViewStylePropTypes';
+import type { SketchContext } from './types';
+import buildTree from './buildTree';
+import flexToSketchJSON from './flexToSketchJSON';
+import compose from './utils/compose';
+
+let id = 0;
+const nextId = () => ++id; // eslint-disable-line
+
+const displayName = (Component: React$Component): string =>
+  Component.displayName || Component.name || `Unknown_${nextId()}`;
+
+const mastersRegistry = {};
+
+const symbolize = (Component: React$Component): React$Component => {
+  const innerName = displayName(Component);
+  const symbolId = generateID();
+
+  mastersRegistry[innerName] = () => (
+    <symbolmaster symbolID={symbolId} name={innerName}>
+      <Component />
+    </symbolmaster>
+  );
+
+  return class extends React.Component {
+    static displayName = `SymbolInstance(${innerName})`;
+
+    static propTypes = {
+      style: PropTypes.shape(ViewStylePropTypes),
+    };
+
+    render() {
+      return (
+        <symbolinstance
+          symbolID={symbolId}
+          name={innerName}
+          style={StyleSheet.flatten(this.props.style)}
+        />
+      );
+    }
+  };
+};
+
+const pageListToArray = (pageList) => {
+  const out = [];
+  // eslint-disable-next-line
+  for (let i = 0; i < pageList.length; i++) {
+    out.push(pageList[i]);
+  }
+  return out;
+};
+
+const inject = (context: SketchContext) => {
+  const pages = context.document.pages();
+  const array = pageListToArray(pages);
+
+  let symbolsPage = array.find(p => String(p.name()) === 'Symbols');
+  if (!symbolsPage) {
+    symbolsPage = context.document.addBlankPage();
+    symbolsPage.setName('Symbols');
+  }
+
+  let notSymbolsPage = array.find(p => String(p.name()) !== 'Symbols');
+  if (!notSymbolsPage) {
+    notSymbolsPage = context.document.addBlankPage();
+  }
+
+  const layers = Object.keys(mastersRegistry).map(k =>
+    compose(fromSJSONDictionary, flexToSketchJSON, buildTree, mastersRegistry[k])()
+  );
+
+  symbolsPage.replaceAllLayersWithLayers(layers);
+  context.document.setCurrentPage(notSymbolsPage);
+};
+
+export default {
+  symbolize,
+  inject,
+};

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import type { SJSymbolMaster } from 'sketchapp-json-flow-types';
-import { fromSJSONDictionary } from 'sketchapp-json-plugin';
+import { fromSJSONDictionary, toSJSON } from 'sketchapp-json-plugin';
 import StyleSheet from './stylesheet';
 import { generateID } from './jsonUtils/models';
 import ViewStylePropTypes from './components/ViewStylePropTypes';
@@ -13,30 +13,13 @@ let id = 0;
 const nextId = () => ++id; // eslint-disable-line
 
 const displayName = (Component: React$Component): string =>
-  Component.displayName || Component.name || `Unknown_${nextId()}`;
+  Component.displayName || Component.name || `UnknownSymbol${nextId()}`;
 
-const mastersSymbolIdRegistry = {};
+const mastersNameRegistry = {};
 
-let masterLeftOffset = 0;
-
-export const makeSymbol = (Component: React$Component): React$Component => {
-  const innerName = displayName(Component);
-  const symbolId = generateID();
-
-  const renderedMaster = flexToSketchJSON(
-    buildTree(
-      <symbolmaster symbolID={symbolId} name={innerName}>
-        <Component />
-      </symbolmaster>
-    )
-  );
-
-  renderedMaster.frame.x = masterLeftOffset;
-  masterLeftOffset += renderedMaster.frame.width + 100;
-  mastersSymbolIdRegistry[symbolId] = renderedMaster;
-
-  return class extends React.Component {
-    static displayName = `SymbolInstance(${innerName})`;
+export const makeSymbolByName = (masterName: string): React$Component =>
+  class extends React.Component {
+    static displayName = `SymbolInstance(${masterName})`;
 
     static propTypes = {
       style: PropTypes.shape(ViewStylePropTypes),
@@ -44,22 +27,35 @@ export const makeSymbol = (Component: React$Component): React$Component => {
       overrides: PropTypes.object // eslint-disable-line
     };
 
-    static symbolId = symbolId;
+    static masterName = masterName;
 
     render() {
       return (
         <symbolinstance
-          symbolID={symbolId}
-          name={this.props.name || innerName}
+          masterName={masterName}
+          name={this.props.name || masterName}
           style={StyleSheet.flatten(this.props.style)}
           overrides={this.props.overrides}
         />
       );
     }
   };
+
+export const makeSymbol = (Component: React$Component): React$Component => {
+  const masterName = displayName(Component);
+
+  mastersNameRegistry[masterName] = flexToSketchJSON(
+    buildTree(
+      <symbolmaster symbolID={generateID()} name={masterName}>
+        <Component />
+      </symbolmaster>
+    )
+  );
+
+  return makeSymbolByName(masterName);
 };
 
-const pageListToArray = (pageList) => {
+const msListToArray = (pageList) => {
   const out = [];
   // eslint-disable-next-line
   for (let i = 0; i < pageList.length; i++) {
@@ -68,9 +64,29 @@ const pageListToArray = (pageList) => {
   return out;
 };
 
+export const getSymbolMasterByName = (name: string): SJSymbolMaster => {
+  // eslint-disable-next-line
+  if (!mastersNameRegistry.hasOwnProperty(name)) {
+    throw new Error('##FIXME## NO MASTER FOR THIS SYMBOL NAME');
+  }
+  return mastersNameRegistry[name];
+};
+
+export const getSymbolMasterById = (symbolId: string): SJSymbolMaster => {
+  const masterName = Object.keys(mastersNameRegistry).find(
+    key => String(mastersNameRegistry[key].symbolID) === symbolId
+  );
+
+  if (typeof masterName === 'undefined') {
+    throw new Error('##FIXME## NO MASTER WITH THAT SYMBOL ID');
+  }
+
+  return mastersNameRegistry[masterName];
+};
+
 export const injectSymbols = (context: SketchContext) => {
   const pages = context.document.pages();
-  const array = pageListToArray(pages);
+  const array = msListToArray(pages);
 
   let symbolsPage = array.find(p => String(p.name()) === 'Symbols');
   if (!symbolsPage) {
@@ -78,23 +94,30 @@ export const injectSymbols = (context: SketchContext) => {
     symbolsPage.setName('Symbols');
   }
 
+  const existingSymbols = msListToArray(symbolsPage.layers()).map(x => JSON.parse(toSJSON(x)));
+  existingSymbols.forEach((symbolMaster) => {
+    if (symbolMaster._class !== 'symbolMaster') return;
+    if (symbolMaster.name in mastersNameRegistry) return;
+    mastersNameRegistry[symbolMaster.name] = symbolMaster;
+  });
+
+  let left = 0;
+  Object.keys(mastersNameRegistry).forEach((key) => {
+    const symbolMaster = mastersNameRegistry[key];
+    symbolMaster.frame.y = 0;
+    symbolMaster.frame.x = left;
+    left += symbolMaster.frame.width + 20;
+  });
+
   let notSymbolsPage = array.find(p => String(p.name()) !== 'Symbols');
   if (!notSymbolsPage) {
     notSymbolsPage = context.document.addBlankPage();
   }
 
-  const layers = Object.keys(mastersSymbolIdRegistry).map(k =>
-    fromSJSONDictionary(mastersSymbolIdRegistry[k])
+  const layers = Object.keys(mastersNameRegistry).map(k =>
+    fromSJSONDictionary(mastersNameRegistry[k])
   );
 
   symbolsPage.replaceAllLayersWithLayers(layers);
   context.document.setCurrentPage(notSymbolsPage);
-};
-
-export const getMasterBySymbolId = (symbolId: string): SJSymbolMaster => {
-  // eslint-disable-next-line
-  if (!mastersSymbolIdRegistry.hasOwnProperty(symbolId)) {
-    throw new Error('##FIXME## NO MASTER FOR THIS SYMBOL ID');
-  }
-  return mastersSymbolIdRegistry[symbolId];
 };

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -17,7 +17,7 @@ const displayName = (Component: React$Component): string =>
 
 const mastersRegistry = {};
 
-const symbolize = (Component: React$Component): React$Component => {
+export const makeSymbol = (Component: React$Component): React$Component => {
   const innerName = displayName(Component);
   const symbolId = generateID();
 
@@ -55,7 +55,7 @@ const pageListToArray = (pageList) => {
   return out;
 };
 
-const inject = (context: SketchContext) => {
+export const injectSymbols = (context: SketchContext) => {
   const pages = context.document.pages();
   const array = pageListToArray(pages);
 
@@ -76,9 +76,4 @@ const inject = (context: SketchContext) => {
 
   symbolsPage.replaceAllLayersWithLayers(layers);
   context.document.setCurrentPage(notSymbolsPage);
-};
-
-export default {
-  symbolize,
-  inject,
 };

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -86,11 +86,9 @@ export const injectSymbols = (context: SketchContext) => {
   context.document.setCurrentPage(notSymbolsPage);
 };
 
-export const getMasterByName = (name: string): ?SJSymbolMaster => mastersNameRegistry[name];
-
 export const getMasterBySymbolId = (symbolId: string): SJSymbolMaster => {
+  // eslint-disable-next-line
   if (!mastersSymbolIdRegistry.hasOwnProperty(symbolId)) {
-    // eslint-disable-line
     throw new Error('##FIXME## NO MASTER FOR THIS SYMBOL ID');
   }
   return mastersSymbolIdRegistry[symbolId];

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -15,20 +15,25 @@ const nextId = () => ++id; // eslint-disable-line
 const displayName = (Component: React$Component): string =>
   Component.displayName || Component.name || `Unknown_${nextId()}`;
 
-const mastersNameRegistry = {};
 const mastersSymbolIdRegistry = {};
+
+let masterLeftOffset = 0;
 
 export const makeSymbol = (Component: React$Component): React$Component => {
   const innerName = displayName(Component);
   const symbolId = generateID();
 
-  mastersNameRegistry[innerName] = mastersSymbolIdRegistry[symbolId] = flexToSketchJSON(
+  const renderedMaster = flexToSketchJSON(
     buildTree(
       <symbolmaster symbolID={symbolId} name={innerName}>
         <Component />
       </symbolmaster>
     )
   );
+
+  renderedMaster.frame.x = masterLeftOffset;
+  masterLeftOffset += renderedMaster.frame.width + 100;
+  mastersSymbolIdRegistry[symbolId] = renderedMaster;
 
   return class extends React.Component {
     static displayName = `SymbolInstance(${innerName})`;
@@ -78,8 +83,8 @@ export const injectSymbols = (context: SketchContext) => {
     notSymbolsPage = context.document.addBlankPage();
   }
 
-  const layers = Object.keys(mastersNameRegistry).map(k =>
-    fromSJSONDictionary(mastersNameRegistry[k])
+  const layers = Object.keys(mastersSymbolIdRegistry).map(k =>
+    fromSJSONDictionary(mastersSymbolIdRegistry[k])
   );
 
   symbolsPage.replaceAllLayersWithLayers(layers);

--- a/src/types.js
+++ b/src/types.js
@@ -6,30 +6,43 @@ export type SketchLayer = any;
 
 export type SketchStyle = any;
 
+export type MSArray<T> = {
+  [key: number]: T,
+  length: number
+};
+
+export type SketchPage = {
+  name: () => string
+};
+
 export type SketchSharedStyleContainer = {
   setObjects: (objects: Array<SketchStyle>) => void,
-  addSharedStyleWithName_firstInstance: (name: string, ins: SketchStyle) => void,
+  addSharedStyleWithName_firstInstance: (name: string, ins: SketchStyle) => void
 };
 
 type MSGradient = any;
 
 type SketchAssetCollection = {
   colors: () => Array<MSColor>,
-  gradients: () => Array<MSGradient>,
+  gradients: () => Array<MSGradient>
 };
 
 export type SketchDocumentData = {
   layerStyles: () => void,
   layerTextStyles: () => SketchSharedStyleContainer,
   layerSymbols: () => void,
-  assets: () => SketchAssetCollection,
+  assets: () => SketchAssetCollection
 };
 
 export type SketchDocument = {
   documentData: () => SketchDocumentData,
+  pages: () => MSArray<SketchPage>,
+  addBlankPage: () => SketchPage,
+  currentPage: SketchPage
 };
+
 export type SketchContext = {
-  document: SketchDocument,
+  document: SketchDocument
 };
 
 // Reacty things
@@ -50,7 +63,7 @@ export type LayoutInfo = {
   left: number,
   right: number,
   bottom: number,
-  direction: 'ltr' | 'rtl',
+  direction: 'ltr' | 'rtl'
 };
 
 export type ViewStyle = {
@@ -118,7 +131,7 @@ export type ViewStyle = {
   borderRightWidth: number,
   borderBottomWidth: number,
   borderLeftWidth: number,
-  opacity: number,
+  opacity: number
 };
 
 export type TextStyle = {
@@ -134,7 +147,7 @@ export type TextStyle = {
   letterSpacing: number,
   lineHeight: number,
   textAlign: 'auto' | 'left' | 'right' | 'center' | 'justify',
-  writingDirection: 'auto' | 'ltr' | 'rtl',
+  writingDirection: 'auto' | 'ltr' | 'rtl'
 };
 
 export type TreeNode = {
@@ -144,7 +157,7 @@ export type TreeNode = {
   layout: LayoutInfo,
   value: ?string,
   props: any,
-  children: ?Array<TreeNode>,
+  children: ?Array<TreeNode>
 };
 
 export type LayerCreator = (
@@ -152,5 +165,5 @@ export type LayerCreator = (
   layout: LayoutInfo,
   textStyle: TextStyle,
   props: any,
-  value: ?string,
+  value: ?string
 ) => SketchLayer;

--- a/src/types.js
+++ b/src/types.js
@@ -11,8 +11,10 @@ export type MSArray<T> = {
   length: number
 };
 
+type NSString = any;
+
 export type SketchPage = {
-  name: () => string
+  name: () => NSString
 };
 
 export type SketchSharedStyleContainer = {

--- a/src/utils/compose.js
+++ b/src/utils/compose.js
@@ -1,0 +1,1 @@
+export default (...fs) => arg => fs.reduceRight((a, f) => f(a), arg);


### PR DESCRIPTION
> For issue #28

Heya!

There are a few things still missing here but I wanted to get this in front of y'all before going down any paths you wouldn't want. I'll outline some things that are missing or weird still but the gist of the API so far can be explained by this example:

```js
import { Widget } from 'my-lib';
import { makeSymbol, injectSymbols, Artboard, render } from 'react-sketchapp';

// Assume that there is a text string with content "Name" and an <Image> with name prop
// "someImage" within Widget
const WidgetSymbol = makeSymbol(Widget);

const Document = () =>
  <Artboard>
    <WidgetSymbol
      style={{width: 100, height: 100 }}
      overrides={{ 'Name': 'Hi', 'someImage': 'https://whatever.example/image.jpg' }}
    />
  </Artboard>;

export default (context) => {
  injectSymbols(context);
  render(<Document />, context.document.currentPage());
};
```

What will happen is a new page called `"Symbols"` will be created if it doesn't already exists and the symbol master generated by the call to `makeSymbol` will be dumped there. Then, each rendered `WidgetSymbol` will be a symbol instance pointing to the related master. Names of things are best guess based on the name of the class, and names are currently shared and global, so if you have two things called `Widget` one will be overwritten.

See also the example in /examples/symbols

### How overrides work

I tried to keep the overrides API as similar to the actual experience in Sketch as possible. There are three overridable elements within a symbol: text, images, and other symbols.

#### Text
Text overrides currently work by mapping _either_ the name from a `<Text />` element or the actual text content onto the key in the overrides object. So, if a symbol master looks like:
```
...
<Text name="my_text">hello</Text>
...
```
Then the override is going to look like
```
<Instance overrides={{ my_text: 'whatever you want here' }} />
```

But, if you just use a string in your master like
```
...
Hello World
...
```
Then the override will look like
```
<Instance overrides={{ 'Hello World': 'Something else' }} />
```

#### Images
Image overrides work by mapping the name assigned to the image element onto another image url string. In the master:
```
... 
<Image name="my_image" source="https://hello.world/image.jpg" />
...
```
And to override:
```
<Instance overrides={{ my_image: 'https://hello.world/different.jpg' }} />
```

#### Nested Symbols
Nested symbols are overrided by mapping the name given to the symbol instance nested within the master onto the constructor for a different symbol instance. The constructor must ultimately point to a master with the exact same width and height as the original. For a master that contains:
```
...
<NestedSymbolA name="nested_symbol" />
...
```
The override is:
```
<Instance overrides={{ nested_symbol: NestedSymbolB, /* any other overrides in Instance _or_ NestedSymbolB */ }} />
```
You'll notice here we can provide overrides at the top level that apply to nested symbols within a master. This applies whether the nested symbol instance has been overrided or not. So if we didn't override `NestedSymbolA` with `NestedSymbolB`, we could include overrides for the contents of `NestedSymbolA`. This is how Sketch presents overrides for nested symbols in its UI, and internally we need to collect all overrides into one object as well so I chose to represent it as a flattened application in the API as well.

### Things that are weird

- `css-layout` wants to see some dimensions on the children of a flex container, so if you just render a symbol like `<MyInstance />` you're going to end up with no width and no height. This is 
counterintuitive -- Sketch seems to clone the layout of the master to each instance when you first create it.

### Things to do

- [x] Automatic symbol master injection
- [x] Automatic symbol instance generation
- [x] Text overrides
- [x] Image overrides
- [x] Symbol instance overrides
- [ ] Use real `sketchapp-json-flow-types` package again once [this PR](https://github.com/darknoon/sketchapp-json-flow-types/pull/6) is merged and published.
