### PR TITLE
Handle string only errors in RedBox.js

### DIFF
--- a/__tests__/components/RedBox.js
+++ b/__tests__/components/RedBox.js
@@ -13,4 +13,10 @@ describe('<RedBox />', () => {
       expect(tree).toMatchSnapshot();
     }
   });
+
+  it('renders string errors', () => {
+    const tree = renderer.create(<RedBox error={'String only error'} />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/__tests__/components/__snapshots__/RedBox.js.snap
+++ b/__tests__/components/__snapshots__/RedBox.js.snap
@@ -141,3 +141,31 @@ exports[`<RedBox /> renders simple errors 1`] = `
   </view>
 </view>
 `;
+
+exports[`<RedBox /> renders string errors 1`] = `
+<view
+  name="RedBox"
+  style={
+    Object {
+      "backgroundColor": "rgb(204, 0, 0)",
+      "paddingBottom": 10,
+      "paddingLeft": 10,
+      "paddingRight": 10,
+      "paddingTop": 10,
+      "width": 480,
+    }
+  }>
+  <text
+    name="Message"
+    style={
+      Object {
+        "color": "white",
+        "fontSize": 16,
+        "fontWeight": "bold",
+        "lineHeight": 19.2,
+      }
+    }>
+    Error: String only error
+  </text>
+</view>
+`;

--- a/src/components/RedBox.js
+++ b/src/components/RedBox.js
@@ -17,7 +17,7 @@ type StackFrame = {
   functionName?: string,
   source?: string,
   args?: any[],
-  evalOrigin?: StackFrame,
+  evalOrigin?: StackFrame
 };
 
 const styles = {
@@ -41,7 +41,7 @@ const styles = {
 };
 
 const propTypes = {
-  error: PropTypes.instanceOf(Error).isRequired,
+  error: PropTypes.oneOfType([PropTypes.instanceOf(Error), PropTypes.string]).isRequired,
   // filename: PropTypes.string,
   // editorScheme: PropTypes.string,
   // useLines: PropTypes.bool,
@@ -60,6 +60,14 @@ class RedBox extends React.Component {
 
   render() {
     const { error } = this.props;
+
+    if (typeof error === 'string') {
+      return (
+        <View name="RedBox" style={styles.redbox}>
+          <Text name="Message" style={styles.message}>{`Error: ${error}`}</Text>
+        </View>
+      );
+    }
 
     let frames;
     let parseError;


### PR DESCRIPTION
This PR fixes #50 by handling `string` only errors in `RedBox.js`. If the encountered error is a string, the `RedBox.js` will render the error in a generic way as early as possible.

In #50 the error was raised by a third party module `chroma.js`, which [only throws strings in the errors](https://github.com/gka/chroma.js/blob/d2c6d917df4ba2b87d8a740de116a0656bcbdfd5/src/converter/in/hex2rgb.coffee#L29) (which is sadly relatively common, I guess).

Before:
![image](https://cloud.githubusercontent.com/assets/7641760/25556103/69f4dac0-2cff-11e7-9d76-2db19fc265b9.png)

After:
![image](https://cloud.githubusercontent.com/assets/7641760/25556101/613acf5c-2cff-11e7-9d78-d8568080d0aa.png)

Signed-off-by: petetnt <pete.a.nykanen@gmail.com>