### PR TITLE
add styled-components example

### DIFF
--- a/examples/styled-components/README.md
+++ b/examples/styled-components/README.md
@@ -1,0 +1,32 @@
+# Styled-components
+
+## How to use
+Download the example or [clone the repo](http://github.com/airbnb/react-sketchapp):
+```
+curl https://codeload.github.com/airbnb/react-sketchapp/tar.gz/master | tar -xz --strip=2 react-sketchapp-master/examples/styled-components
+cd styled-components
+```
+
+Install the dependencies
+```
+npm install
+```
+
+### Run it in Sketch
+Run with live reloading in Sketch
+```
+npm run render
+```
+
+Or, to install as a Sketch plugin:
+```
+npm run build
+npm run link-plugin
+```
+
+Then, open Sketch and navigate to `Plugins → react-sketchapp: Styled components`
+
+
+## The idea behind the example
+
+`styled-components` allows you to write actual CSS code to style your components. It also removes the mapping between components and styles

--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -23,6 +23,6 @@
     "react-primitives": "^0.4.2",
     "react-sketchapp": "^0.11.0",
     "react-test-renderer": "^15.4.2",
-    "styled-components": "git+https://github.com/mathieudutour/styled-components.git#built"
+    "styled-components": "^2.1.0"
   }
 }

--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "styled-components-example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "styled-components.sketchplugin",
+  "manifest": "src/manifest.json",
+  "scripts": {
+    "build": "skpm build",
+    "watch": "skpm build --watch",
+    "render": "skpm build --watch --run",
+    "render:once": "skpm build --run",
+    "link-plugin": "skpm link"
+  },
+  "author": "Mathieu Dutour <mathieu@dutour.me>",
+  "license": "MIT",
+  "devDependencies": {
+    "skpm": "^0.9.0"
+  },
+  "dependencies": {
+    "chroma-js": "^1.2.2",
+    "prop-types": "^15.5.8",
+    "react": "^15.4.2",
+    "react-primitives": "^0.4.2",
+    "react-sketchapp": "^0.11.0",
+    "react-test-renderer": "^15.4.2",
+    "styled-components": "git+https://github.com/mathieudutour/styled-components.git#built"
+  }
+}

--- a/examples/styled-components/src/manifest.json
+++ b/examples/styled-components/src/manifest.json
@@ -1,0 +1,17 @@
+{
+	"compatibleVersion": 3,
+	"bundleVersion": 1,
+	"commands": [
+		{
+			"name": "react-sketchapp: Styled components",
+			"identifier": "main",
+			"script": "./my-command.js"
+		}
+	],
+	"menu": {
+		"isRoot": true,
+		"items": [
+			"main"
+		]
+	}
+}

--- a/examples/styled-components/src/my-command.js
+++ b/examples/styled-components/src/my-command.js
@@ -24,7 +24,7 @@ const SwatchTile = styled.View`
 
 const SwatchName = styled.Text`
   color: ${props => textColor(props.hex)};
-  font-weight: 'bold';
+  font-weight: bold;
 `;
 
 const SwatchHex = styled.Text`

--- a/examples/styled-components/src/my-command.js
+++ b/examples/styled-components/src/my-command.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import 'react-primitives';
 import styled from 'styled-components/primitives';
 import { render } from 'react-sketchapp';
 import chroma from 'chroma-js';
@@ -15,11 +14,13 @@ const textColor = (hex) => {
 };
 
 const SwatchTile = styled.View`
-  height: 96px;
-  width: 96px;
+  height: 250px;
+  width: 250px;
+  border-radius: 4px;
   margin: 4px;
   background-color: ${props => props.hex};
-  padding: 8px;
+  justify-content: center;
+  align-items: center;
 `;
 
 const SwatchName = styled.Text`
@@ -27,18 +28,26 @@ const SwatchName = styled.Text`
   font-weight: bold;
 `;
 
-const SwatchHex = styled.Text`
-  color: ${props => textColor(props.hex)};
+const Ampersand = styled.Text`
+  color: #f3f3f3;
+  font-size: 120px;
+  font-family: Himalaya;
+  line-height: 144px;
 `;
+
+const Title = styled.Text`
+  font-size: 24px;
+  font-family: "GT America";
+  font-weight: bold;
+  padding: 4px;
+`
 
 const Swatch = ({ name, hex }) => (
   <SwatchTile name={`Swatch ${name}`} hex={hex}>
     <SwatchName name="Swatch Name" hex={hex}>
       {name}
     </SwatchName>
-    <SwatchHex name="Swatch Hex" hex={hex}>
-      {hex}
-    </SwatchHex>
+    <Ampersand hex={hex}>&</Ampersand>
   </SwatchTile>
 );
 
@@ -53,10 +62,12 @@ const Artboard = styled.View`
   flex-direction: row;
   flex-wrap: wrap;
   width: ${(96 + 8) * 4}px;
+  justify-content: center;
 `;
 
 const Document = ({ colors }) => (
   <Artboard name="Swatches">
+    <Title>Max’s Sweaters</Title>
     {Object.keys(colors).map(color => <Swatch name={color} hex={colors[color]} key={color} />)}
   </Artboard>
 );
@@ -67,14 +78,8 @@ Document.propTypes = {
 
 export default (context) => {
   const colorList = {
-    Haus: '#F3F4F4',
-    Night: '#333',
-    Sur: '#96DBE4',
-    'Sur Dark': '#24828F',
-    Peach: '#EFADA0',
-    'Peach Dark': '#E37059',
-    Pear: '#93DAAB',
-    'Pear Dark': '#2E854B',
+    Classic: '#96324E',
+    Neue: '#21304E',
   };
 
   render(<Document colors={colorList} />, context.document.currentPage());

--- a/examples/styled-components/src/my-command.js
+++ b/examples/styled-components/src/my-command.js
@@ -15,20 +15,20 @@ const textColor = (hex) => {
 };
 
 const SwatchTile = styled.View`
-  height: 96,
-  width: 96,
-  margin: 4,
-  backgroundColor: ${props => props.hex},
-  padding: 8,
+  height: 96px;
+  width: 96px;
+  margin: 4px;
+  background-color: ${props => props.hex};
+  padding: 8px;
 `;
 
 const SwatchName = styled.Text`
-  color: ${props => textColor(props.hex)},
-  fontWeight: 'bold',
+  color: ${props => textColor(props.hex)};
+  font-weight: 'bold';
 `;
 
 const SwatchHex = styled.Text`
-  color: ${props => textColor(props.hex)},
+  color: ${props => textColor(props.hex)};
 `;
 
 const Swatch = ({ name, hex }) => (
@@ -50,9 +50,9 @@ const Color = {
 Swatch.propTypes = Color;
 
 const Artboard = styled.View`
-  flexDirection: 'row',
-  flexWrap: 'wrap',
-  width: ${(96 + 8) * 4}
+  flex-direction: row;
+  flex-wrap: wrap;
+  width: ${(96 + 8) * 4}px;
 `;
 
 const Document = ({ colors }) => (

--- a/examples/styled-components/src/my-command.js
+++ b/examples/styled-components/src/my-command.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import 'react-primitives';
+import styled from 'styled-components/primitives';
+import { render } from 'react-sketchapp';
+import chroma from 'chroma-js';
+
+// take a hex and give us a nice text color to put over it
+const textColor = (hex) => {
+  const vsWhite = chroma.contrast(hex, 'white');
+  if (vsWhite > 4) {
+    return '#FFF';
+  }
+  return chroma(hex).darken(3).hex();
+};
+
+const SwatchTile = styled.View`
+  height: 96,
+  width: 96,
+  margin: 4,
+  backgroundColor: ${props => props.hex},
+  padding: 8,
+`;
+
+const SwatchName = styled.Text`
+  color: ${props => textColor(props.hex)},
+  fontWeight: 'bold',
+`;
+
+const SwatchHex = styled.Text`
+  color: ${props => textColor(props.hex)},
+`;
+
+const Swatch = ({ name, hex }) => (
+  <SwatchTile name={`Swatch ${name}`} hex={hex}>
+    <SwatchName name="Swatch Name" hex={hex}>
+      {name}
+    </SwatchName>
+    <SwatchHex name="Swatch Hex" hex={hex}>
+      {hex}
+    </SwatchHex>
+  </SwatchTile>
+);
+
+const Color = {
+  hex: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+};
+
+Swatch.propTypes = Color;
+
+const Artboard = styled.View`
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  width: ${(96 + 8) * 4}
+`;
+
+const Document = ({ colors }) => (
+  <Artboard name="Swatches">
+    {Object.keys(colors).map(color => <Swatch name={color} hex={colors[color]} key={color} />)}
+  </Artboard>
+);
+
+Document.propTypes = {
+  colors: PropTypes.objectOf(PropTypes.string).isRequired,
+};
+
+export default (context) => {
+  const colorList = {
+    Haus: '#F3F4F4',
+    Night: '#333',
+    Sur: '#96DBE4',
+    'Sur Dark': '#24828F',
+    Peach: '#EFADA0',
+    'Peach Dark': '#E37059',
+    Pear: '#93DAAB',
+    'Pear Dark': '#2E854B',
+  };
+
+  render(<Document colors={colorList} />, context.document.currentPage());
+};


### PR DESCRIPTION
I played around adding `react-primitives` to `styled-components` which means that you can use it in react-sketchapp as well!

fix #39
