### PR TITLE
Specify files for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "react": "*",
     "react-test-renderer": "*"
   },
+  "files": [
+    "lib"
+  ],
   "keywords": [
     "sketch",
     "sketchapp",


### PR DESCRIPTION
The [npm `files` property](https://docs.npmjs.com/files/package.json#files) isn't specified, which results in downloading all the `react-sketchapp` repo at each `npm install`.

I added the `lib` directory to the files, as I believe this is the only one we need.