### PR TITLE
Replace removed replaceAllLayersWithLayers API (Sketch 45) with addLayers

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -22,11 +22,20 @@ const renderToSketch = (
   const json = flexToSketchJSON(node);
   const layer = fromSJSONDictionary(json);
 
+  if (container.addLayers === undefined) {
+    throw new Error(`
+     React SketchApp cannot render into this layer. You may be trying to render into a layer
+     that does not take children. Try rendering into a LayerGroup, Artboard, or Page.
+    `);
+  }
+
   if (container.containsLayers()) {
     const loop = container.children().objectEnumerator();
     let currLayer = loop.nextObject();
     while (currLayer) {
-      currLayer.removeFromParent();
+      if (currLayer !== container) {
+        currLayer.removeFromParent();
+      }
       currLayer = loop.nextObject();
     }
   }

--- a/src/render.js
+++ b/src/render.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import type { SJLayer } from 'sketchapp-json-flow-types';
-import { appVersionSupported, fromSJSONDictionary } from 'sketchapp-json-plugin';
+import {
+  appVersionSupported,
+  fromSJSONDictionary,
+} from 'sketchapp-json-plugin';
 import buildTree from './buildTree';
 import flexToSketchJSON from './flexToSketchJSON';
 
@@ -12,14 +15,30 @@ export const renderToJSON = (element: React$Element<any>): SJLayer => {
   return flexToSketchJSON(tree);
 };
 
-const renderToSketch = (node: TreeNode, container: SketchLayer): SketchLayer => {
+const renderToSketch = (
+  node: TreeNode,
+  container: SketchLayer
+): SketchLayer => {
   const json = flexToSketchJSON(node);
   const layer = fromSJSONDictionary(json);
-  container.replaceAllLayersWithLayers([layer]);
+
+  if (container.containsLayers()) {
+    const loop = container.children().objectEnumerator();
+    let currLayer = loop.nextObject();
+    while (currLayer) {
+      currLayer.removeFromParent();
+      currLayer = loop.nextObject();
+    }
+  }
+
+  container.addLayers([layer]);
   return container;
 };
 
-export const render = (element: React$Element<any>, container: SketchLayer): ?SketchLayer => {
+export const render = (
+  element: React$Element<any>,
+  container: SketchLayer
+): ?SketchLayer => {
   if (appVersionSupported()) {
     try {
       const tree = buildTree(element);


### PR DESCRIPTION
Fixes https://github.com/airbnb/react-sketchapp/issues/133.

Alternative solution to https://github.com/airbnb/react-sketchapp/pull/134 as this also removes all the existing layers before adding the new layer (essentially emulating `replaceAllLayersWithLayers`).