### PR TITLE
Fix shadowOpacity property

### DIFF
--- a/__tests__/jsonUtils/models.js
+++ b/__tests__/jsonUtils/models.js
@@ -57,6 +57,12 @@ describe('makeColorFromCSS', () => {
     expect(makeColorFromCSS('rgba(102, 51, 153, 1)')).toEqual(PURPLE);
   });
 
+  it('multiplies rgba components with an alpha', () => {
+    expect(makeColorFromCSS('rgba(0, 0, 0, 0.5)').alpha).toBeCloseTo(0.5);
+    expect(makeColorFromCSS('rgba(0, 0, 0, 1)', 0.5).alpha).toBeCloseTo(0.5);
+    expect(makeColorFromCSS('rgba(0, 0, 0, 0.5)', 0.5).alpha).toBeCloseTo(0.25);
+  });
+
   it('works with hsl colors', () => {
     expect(makeColorFromCSS('hsl(0, 0%, 0%)')).toEqual(BLACK);
     expect(makeColorFromCSS('hsl(0, 0%, 100%)')).toEqual(WHITE);

--- a/__tests__/jsonUtils/style.js
+++ b/__tests__/jsonUtils/style.js
@@ -6,15 +6,27 @@ describe('makeBorderOptions', () => {
   });
 
   it('makes dotted borders', () => {
-    expect(makeBorderOptions('dotted', 1)).toHaveProperty('dashPattern', [1, 1]);
+    expect(makeBorderOptions('dotted', 1)).toHaveProperty('dashPattern', [
+      1,
+      1,
+    ]);
 
-    expect(makeBorderOptions('dotted', 5)).toHaveProperty('dashPattern', [5, 5]);
+    expect(makeBorderOptions('dotted', 5)).toHaveProperty('dashPattern', [
+      5,
+      5,
+    ]);
   });
 
   it('makes dashed borders', () => {
-    expect(makeBorderOptions('dashed', 1)).toHaveProperty('dashPattern', [3, 3]);
+    expect(makeBorderOptions('dashed', 1)).toHaveProperty('dashPattern', [
+      3,
+      3,
+    ]);
 
-    expect(makeBorderOptions('dashed', 5)).toHaveProperty('dashPattern', [15, 15]);
+    expect(makeBorderOptions('dashed', 5)).toHaveProperty('dashPattern', [
+      15,
+      15,
+    ]);
   });
 });
 
@@ -22,7 +34,7 @@ describe('makeShadow', () => {
   it('has sensible defaults', () => {
     const result = makeShadow({});
 
-    expect(result).toHaveProperty('contextSettings.opacity', 1);
+    expect(result).toHaveProperty('color.alpha', 1);
     expect(result).toHaveProperty('blurRadius', 1);
     expect(result).toHaveProperty('offsetX', 0);
     expect(result).toHaveProperty('offsetY', 0);
@@ -39,10 +51,24 @@ describe('makeShadow', () => {
       },
     });
 
-    expect(result).toHaveProperty('contextSettings.opacity', 0.5);
+    expect(result).toHaveProperty('color.alpha', 0.5);
     expect(result).toHaveProperty('blurRadius', 10);
     expect(result).toHaveProperty('offsetX', 5);
     expect(result).toHaveProperty('offsetY', 7);
+  });
+
+  it('combines rgba alpha & shadowOpacity', () => {
+    const result = makeShadow({
+      shadowOpacity: 0.5,
+      shadowColor: 'rgba(0,0,0,0.5)',
+      shadowRadius: 10,
+      shadowOffset: {
+        width: 5,
+        height: 7,
+      },
+    });
+
+    expect(result.color.alpha).toBeCloseTo(0.25);
   });
 });
 

--- a/src/jsonUtils/models.js
+++ b/src/jsonUtils/models.js
@@ -22,7 +22,16 @@ function e7() {
   const d1 = (Math.random() * 0xffffffff) | 0;
   const d2 = (Math.random() * 0xffffffff) | 0;
   const d3 = (Math.random() * 0xffffffff) | 0;
-  return `${lut[d0 & 0xff] + lut[(d0 >> 8) & 0xff] + lut[(d0 >> 16) & 0xff] + lut[(d0 >> 24) & 0xff]}-${lut[d1 & 0xff]}${lut[(d1 >> 8) & 0xff]}-${lut[((d1 >> 16) & 0x0f) | 0x40]}${lut[(d1 >> 24) & 0xff]}-${lut[(d2 & 0x3f) | 0x80]}${lut[(d2 >> 8) & 0xff]}-${lut[(d2 >> 16) & 0xff]}${lut[(d2 >> 24) & 0xff]}${lut[d3 & 0xff]}${lut[(d3 >> 8) & 0xff]}${lut[(d3 >> 16) & 0xff]}${lut[(d3 >> 24) & 0xff]}`;
+  return `${lut[d0 & 0xff] +
+    lut[(d0 >> 8) & 0xff] +
+    lut[(d0 >> 16) & 0xff] +
+    lut[(d0 >> 24) & 0xff]}-${lut[d1 & 0xff]}${lut[(d1 >> 8) & 0xff]}-${lut[
+    ((d1 >> 16) & 0x0f) | 0x40
+  ]}${lut[(d1 >> 24) & 0xff]}-${lut[(d2 & 0x3f) | 0x80]}${lut[
+    (d2 >> 8) & 0xff
+  ]}-${lut[(d2 >> 16) & 0xff]}${lut[(d2 >> 24) & 0xff]}${lut[d3 & 0xff]}${lut[
+    (d3 >> 8) & 0xff
+  ]}${lut[(d3 >> 16) & 0xff]}${lut[(d3 >> 24) & 0xff]}`;
 }
 
 export function generateID(): string {
@@ -38,7 +47,7 @@ const safeToLower = (input: Color): Color => {
 };
 
 // Takes colors as CSS hex, name, rgb, rgba, hsl or hsla
-export const makeColorFromCSS = (input: Color): SJColor => {
+export const makeColorFromCSS = (input: Color, alpha: number = 1): SJColor => {
   const nullableColor: ?number = normalizeColor(safeToLower(input));
   const colorInt: number = nullableColor == null ? 0x00000000 : nullableColor;
   const { r, g, b, a } = normalizeColor.rgba(colorInt);
@@ -48,7 +57,7 @@ export const makeColorFromCSS = (input: Color): SJColor => {
     red: r / 255,
     green: g / 255,
     blue: b / 255,
-    alpha: a,
+    alpha: a * alpha,
   };
 };
 
@@ -79,7 +88,12 @@ export const makeImageFill = (
 });
 
 // Used in frames, etc
-export const makeRect = (x: number, y: number, width: number, height: number): SJRect => ({
+export const makeRect = (
+  x: number,
+  y: number,
+  width: number,
+  height: number
+): SJRect => ({
   _class: 'rect',
   constrainProportions: false,
   x,
@@ -88,20 +102,26 @@ export const makeRect = (x: number, y: number, width: number, height: number): S
   height,
 });
 
-export const makeJSONDataReference = (image: MSImageData): SJImageDataReference => ({
+export const makeJSONDataReference = (
+  image: MSImageData
+): SJImageDataReference => ({
   _class: 'MSJSONOriginalDataReference',
   _ref: `images/${generateID()}`,
   _ref_class: 'MSImageData',
   data: {
     _data: image
       .data()
-      .base64EncodedStringWithOptions(NSDataBase64EncodingEndLineWithCarriageReturn),
+      .base64EncodedStringWithOptions(
+        NSDataBase64EncodingEndLineWithCarriageReturn
+      ),
     // TODO(gold): can I just declare this as a var instead of using Cocoa?
   },
   sha1: {
     _data: image
       .sha1()
-      .base64EncodedStringWithOptions(NSDataBase64EncodingEndLineWithCarriageReturn),
+      .base64EncodedStringWithOptions(
+        NSDataBase64EncodingEndLineWithCarriageReturn
+      ),
   },
 });
 

--- a/src/jsonUtils/style.js
+++ b/src/jsonUtils/style.js
@@ -1,6 +1,10 @@
 /* @flow */
 import { BorderPosition } from 'sketch-constants';
-import type { SJBorderOptions, SJShadow, SJShapeGroupLayer } from 'sketchapp-json-flow-types';
+import type {
+  SJBorderOptions,
+  SJShadow,
+  SJShapeGroupLayer,
+} from 'sketchapp-json-flow-types';
 import { makeRect, makeColorFromCSS } from '../jsonUtils/models';
 import {
   makeHorizontalPath,
@@ -12,7 +16,10 @@ import type { Color, ViewStyle } from '../types';
 
 const DEFAULT_SHADOW_COLOR = '#000';
 
-const makeDashPattern = (style: 'dashed' | 'dotted' | 'solid', width: number): Array<number> => {
+const makeDashPattern = (
+  style: "dashed" | "dotted" | "solid",
+  width: number
+): Array<number> => {
   switch (style) {
     case 'dashed':
       return [width * 3, width * 3];
@@ -26,8 +33,8 @@ const makeDashPattern = (style: 'dashed' | 'dotted' | 'solid', width: number): A
 };
 
 export const makeBorderOptions = (
-  style: 'dashed' | 'dotted' | 'solid',
-  width: number,
+  style: "dashed" | "dotted" | "solid",
+  width: number
 ): SJBorderOptions => ({
   _class: 'borderOptions',
   isEnabled: false,
@@ -46,11 +53,11 @@ export const makeShadow = (style: ViewStyle): SJShadow => {
     _class: 'shadow',
     isEnabled: true,
     blurRadius: radius,
-    color: makeColorFromCSS(color),
+    color: makeColorFromCSS(color, opacity),
     contextSettings: {
       _class: 'graphicsContextSettings',
       blendMode: 0,
-      opacity,
+      opacity: 1,
     },
     offsetX,
     offsetY,
@@ -63,7 +70,7 @@ export const makeVerticalBorder = (
   y: number,
   length: number,
   thickness: number,
-  color: Color,
+  color: Color
 ): SJShapeGroupLayer => {
   const frame = makeRect(x, y, thickness, length);
   const shapeFrame = makeRect(0, 0, thickness, length);
@@ -87,7 +94,7 @@ export const makeHorizontalBorder = (
   y: number,
   length: number,
   thickness: number,
-  color: Color,
+  color: Color
 ): SJShapeGroupLayer => {
   const frame = makeRect(x, y, length, thickness);
   const shapeFrame = makeRect(0, 0, length, thickness);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/591643/27714069-a5c317b0-5ce3-11e7-9420-b928c58d295c.png)

React Native multiplies together a `shadowColor`'s alpha value with the `shadowOpacity` value — in Sketch we equally only have one way to control a shadow opacity.