### PR TITLE
Add support for textDecorationLine property

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -78,6 +78,7 @@ Components use CSS styles + flexbox layout.
 | `fontSize` | `number` | ✅ |
 | `fontStyle` | `normal` &#124; `italic` | ✅ |
 | `fontWeight` | `string` | ✅ |
+| `textDecorationLine` | `none` &#124; `underline` &#124; `double` &#124; `line-through`  | ✅ |
 | `textShadowOffset` | `{ width: number, height: number }` | ⛔️ |
 | `textShadowRadius` | `number` | ⛔️ |
 | `textShadowColor` | `Color` | ⛔️ |

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -12,13 +12,14 @@ const INHERITABLE_STYLES = [
   'fontSize',
   'fontStyle',
   'fontWeight',
+  'textAlign',
+  'textDecoration',
   'textShadowOffset',
   'textShadowRadius',
   'textShadowColor',
   'textTransform',
   'letterSpacing',
   'lineHeight',
-  'textAlign',
   'writingDirection',
 ];
 

--- a/src/jsonUtils/hacksForJSONImpl.js
+++ b/src/jsonUtils/hacksForJSONImpl.js
@@ -15,6 +15,17 @@ export const TEXT_ALIGN = {
   justify: TextAlignment.Justified,
 };
 
+export const TEXT_DECORATION_UNDERLINE = {
+  none: 0,
+  underline: 1,
+  double: 9,
+};
+
+export const TEXT_DECORATION_LINETHROUGH = {
+  none: 0,
+  'line-through': 1,
+};
+
 // this doesn't exist in constants
 export const TEXT_TRANSFORM = {
   uppercase: 1,
@@ -72,7 +83,8 @@ export const makeImageDataFromUrl = (url: string): MSImageData => {
   let image;
 
   if (!fetchedData) {
-    const errorUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mM8w8DwHwAEOQHNmnaaOAAAAABJRU5ErkJggg==';
+    const errorUrl =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mM8w8DwHwAEOQHNmnaaOAAAAABJRU5ErkJggg==';
     image = NSImage.alloc().initWithContentsOfURL(
       NSURL.URLWithString(errorUrl)
     );
@@ -96,8 +108,10 @@ export function makeAttributedString(string: ?string, textStyle: TextStyle) {
       color.red,
       color.green,
       color.blue,
-      color.alpha,
+      color.alpha
     ),
+    NSUnderline: TEXT_DECORATION_UNDERLINE[textStyle.textDecoration] || 0,
+    NSStrikethrough: TEXT_DECORATION_LINETHROUGH[textStyle.textDecoration] || 0,
   };
 
   if (textStyle.letterSpacing !== undefined) {
@@ -105,11 +119,17 @@ export function makeAttributedString(string: ?string, textStyle: TextStyle) {
   }
 
   if (textStyle.textTransform !== undefined) {
-    attribs.MSAttributedStringTextTransformAttribute = TEXT_TRANSFORM[textStyle.textTransform] * 1;
+    attribs.MSAttributedStringTextTransformAttribute =
+      TEXT_TRANSFORM[textStyle.textTransform] * 1;
   }
 
-  const attribStr = NSAttributedString.attributedStringWithString_attributes_(string, attribs);
-  const msAttribStr = MSAttributedString.alloc().initWithAttributedString(attribStr);
+  const attribStr = NSAttributedString.attributedStringWithString_attributes_(
+    string,
+    attribs
+  );
+  const msAttribStr = MSAttributedString.alloc().initWithAttributedString(
+    attribStr
+  );
 
   return encodeSketchJSON(msAttribStr);
 }
@@ -130,14 +150,13 @@ export function makeTextStyle(textStyle: TextStyle) {
           color.red,
           color.green,
           color.blue,
-          color.alpha,
-        ),
+          color.alpha
+        )
       ),
       NSParagraphStyle: encodeSketchJSON(pStyle),
       NSKern: textStyle.letterSpacing || 0,
-      MSAttributedStringTextTransformAttribute: TEXT_TRANSFORM[
-        textStyle.textTransform || 'initial'
-      ] * 1,
+      MSAttributedStringTextTransformAttribute:
+        TEXT_TRANSFORM[textStyle.textTransform || 'initial'] * 1,
     },
   };
 


### PR DESCRIPTION
Hi, this adds support for the textDecorationLine property for text.
Tested on ***Sketch 44.1***
Example of usage:
```js
<Text  style={{textDecorationLine: 'underline'}}>
  Hello World
</Text>
```

which outputs this:
![screen shot 2017-07-07 at 11 13 54 am](https://user-images.githubusercontent.com/4756314/27970906-7e3fc0ee-6305-11e7-9af6-3c57c7ff5471.png)

The API supports the following attributes: `none`, `underline`, `line-through`, `double`.

I have some questions though:
* Should I create some tests around this?
* How about the documentation, does this grant an update?
* There was an autoformat on commit, I didn't make some of those changes. is that okay?