### PR TITLE
Allow naming symbols; change symbol page selector

### DIFF
--- a/examples/symbols/src/my-command.js
+++ b/examples/symbols/src/my-command.js
@@ -9,7 +9,7 @@ const RedSquare = () => (
   </View>
 );
 
-const RedSquareSym = makeSymbol(RedSquare);
+const RedSquareSym = makeSymbol(RedSquare, 'squares/red');
 
 const BlueSquare = () => (
   <View name="Square" style={{ width: 100, height: 100, backgroundColor: 'blue' }}>
@@ -19,7 +19,7 @@ const BlueSquare = () => (
   </View>
 );
 
-const BlueSquareSym = makeSymbol(BlueSquare);
+const BlueSquareSym = makeSymbol(BlueSquare, 'squares/blue');
 
 const Photo = () => (
   <Image

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -71,11 +71,9 @@ const injectSymbols = () => {
   const pages = globalContext.document.pages();
   const array = msListToArray(pages);
 
-  let symbolsPage = array.find(p => String(p.name()) === 'Symbols');
-  if (!symbolsPage) {
-    symbolsPage = globalContext.document.addBlankPage();
-    symbolsPage.setName('Symbols');
-  }
+  const symbolsPage = globalContext.document
+    .documentData()
+    .symbolsPageOrCreateIfNecessary();
 
   let left = 0;
   Object.keys(mastersNameRegistry).forEach((key) => {
@@ -124,8 +122,11 @@ export const makeSymbolByName = (masterName: string): React$Component =>
     }
   };
 
-export const makeSymbol = (Component: React$Component): React$Component => {
-  const masterName = displayName(Component);
+export const makeSymbol = (
+  Component: React$Component,
+  name: string
+): React$Component => {
+  const masterName = name || displayName(Component);
 
   if (mastersNameRegistry === null) {
     getExistingSymbols();


### PR DESCRIPTION
![screen shot 2017-07-28 at 8 55 26 am](https://user-images.githubusercontent.com/1259057/28726279-7a553240-7375-11e7-9f6d-40f032847b1b.png)

Naming allows symbols to be put into groups, as above. Names are still not required and will be pulled from the object as before if not assigned.

@bomberstudios pointed out the provided way to find the Symbols page in my last PR and I've also added that and tested both things in v43.2 44.1 and 45.2
