### PR TITLE
fix(box-shadow): Resolve box-shadow spread

### DIFF
--- a/src/jsonUtils/style.js
+++ b/src/jsonUtils/style.js
@@ -47,6 +47,7 @@ export const makeShadow = (style: ViewStyle): SJShadow => {
   const opacity = style.shadowOpacity !== undefined ? style.shadowOpacity : 1;
   const color = style.shadowColor || style.color || DEFAULT_SHADOW_COLOR;
   const radius = style.shadowRadius !== undefined ? style.shadowRadius : 1;
+  const spread = style.shadowSpread !== undefined ? style.shadowSpread : 0;
   const { width: offsetX = 0, height: offsetY = 0 } = style.shadowOffset || {};
 
   return {
@@ -61,7 +62,7 @@ export const makeShadow = (style: ViewStyle): SJShadow => {
     },
     offsetX,
     offsetY,
-    spread: 0,
+    spread,
   };
 };
 


### PR DESCRIPTION
Instead of hard-coding the box shadow spread property, this fix will pick up a spread if defined and will default to `0`