### PR TITLE
feat(inner-shadow): Add possibility to define inner shadows

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "normalize-css-color": "^1.0.1",
     "prop-types": "^15.5.8",
     "sketch-constants": "^1.0.2",
-    "sketchapp-json-flow-types": "github:jongold/sketchapp-json-flow-types#gold/fix-SJShapeLayer",
+    "sketchapp-json-flow-types": "^0.2.0",
     "sketchapp-json-plugin": "^0.0.3"
   },
   "peerDependencies": {

--- a/src/jsonUtils/style.js
+++ b/src/jsonUtils/style.js
@@ -47,10 +47,11 @@ export const makeShadow = (style: ViewStyle): SJShadow => {
   const opacity = style.shadowOpacity !== undefined ? style.shadowOpacity : 1;
   const color = style.shadowColor || style.color || DEFAULT_SHADOW_COLOR;
   const radius = style.shadowRadius !== undefined ? style.shadowRadius : 1;
+  const _class = style.shadowInner !== undefined ? 'innerShadow' : 'shadow';
   const { width: offsetX = 0, height: offsetY = 0 } = style.shadowOffset || {};
 
   return {
-    _class: 'shadow',
+    _class,
     isEnabled: true,
     blurRadius: radius,
     color: makeColorFromCSS(color, opacity),

--- a/src/renderers/ViewRenderer.js
+++ b/src/renderers/ViewRenderer.js
@@ -45,7 +45,12 @@ const VISIBLE_STYLES = [
 
 const OVERFLOW_STYLES = ['overflow', 'overflowX', 'overflowY'];
 
-const SHADOW_STYLES = ['shadowColor', 'shadowOffset', 'shadowOpacity', 'shadowRadius'];
+const SHADOW_STYLES = [
+  'shadowColor',
+  'shadowOffset',
+  'shadowOpacity',
+  'shadowRadius',
+];
 
 class ViewRenderer extends SketchRenderer {
   getDefaultGroupName() {
@@ -57,7 +62,7 @@ class ViewRenderer extends SketchRenderer {
     textStyle: TextStyle,
     props: any,
     // eslint-disable-next-line no-unused-vars
-    value: ?string,
+    value: ?string
   ): Array<SJShapeGroupLayer> {
     const layers = [];
     // NOTE(lmr): the group handles the position, so we just care about width/height here
@@ -96,13 +101,24 @@ class ViewRenderer extends SketchRenderer {
       borderBottomRightRadius,
       borderBottomLeftRadius,
     ];
-    const shapeLayer = makeRectShapeLayer(0, 0, layout.width, layout.height, radii);
+    const shapeLayer = makeRectShapeLayer(
+      0,
+      0,
+      layout.width,
+      layout.height,
+      radii
+    );
 
     const fill = makeColorFill(backgroundColor);
     const content = makeShapeGroup(frame, [shapeLayer], [fill]);
 
     if (hasAnyDefined(style, SHADOW_STYLES)) {
-      content.style.shadows = [makeShadow(style)];
+      const shadow = [makeShadow(style)];
+      if (style.shadowInner) {
+        content.style.innerShadows = shadow;
+      } else {
+        content.style.shadows = shadow;
+      }
     }
 
     if (hasAnyDefined(style, OVERFLOW_STYLES)) {
@@ -119,8 +135,18 @@ class ViewRenderer extends SketchRenderer {
     }
 
     if (
-      same(borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth) &&
-      same(borderTopColor, borderRightColor, borderBottomColor, borderLeftColor) &&
+      same(
+        borderTopWidth,
+        borderRightWidth,
+        borderBottomWidth,
+        borderLeftWidth
+      ) &&
+      same(
+        borderTopColor,
+        borderRightColor,
+        borderBottomColor,
+        borderLeftColor
+      ) &&
       same(borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle)
     ) {
       // all sides have same border width
@@ -150,7 +176,13 @@ class ViewRenderer extends SketchRenderer {
       layers.push(content);
 
       if (borderTopWidth > 0) {
-        const topBorder = makeHorizontalBorder(0, 0, layout.width, borderTopWidth, borderTopColor);
+        const topBorder = makeHorizontalBorder(
+          0,
+          0,
+          layout.width,
+          borderTopWidth,
+          borderTopColor
+        );
         topBorder.name = 'Border (top)';
 
         const borderOptions = makeBorderOptions(borderTopStyle, borderTopWidth);
@@ -167,11 +199,14 @@ class ViewRenderer extends SketchRenderer {
           0,
           layout.height,
           borderRightWidth,
-          borderRightColor,
+          borderRightColor
         );
         rightBorder.name = 'Border (right)';
 
-        const borderOptions = makeBorderOptions(borderRightStyle, borderRightWidth);
+        const borderOptions = makeBorderOptions(
+          borderRightStyle,
+          borderRightWidth
+        );
         if (borderOptions) {
           rightBorder.style.borderOptions = borderOptions;
         }
@@ -185,11 +220,14 @@ class ViewRenderer extends SketchRenderer {
           layout.height - borderBottomWidth,
           layout.width,
           borderBottomWidth,
-          borderBottomColor,
+          borderBottomColor
         );
         bottomBorder.name = 'Border (bottom)';
 
-        const borderOptions = makeBorderOptions(borderBottomStyle, borderBottomWidth);
+        const borderOptions = makeBorderOptions(
+          borderBottomStyle,
+          borderBottomWidth
+        );
         if (borderOptions) {
           bottomBorder.style.borderOptions = borderOptions;
         }
@@ -203,11 +241,14 @@ class ViewRenderer extends SketchRenderer {
           0,
           layout.height,
           borderLeftWidth,
-          borderLeftColor,
+          borderLeftColor
         );
         leftBorder.name = 'Border (left)';
 
-        const borderOptions = makeBorderOptions(borderLeftStyle, borderLeftWidth);
+        const borderOptions = makeBorderOptions(
+          borderLeftStyle,
+          borderLeftWidth
+        );
         if (borderOptions) {
           leftBorder.style.borderOptions = borderOptions;
         }


### PR DESCRIPTION
I'd like to be able to define innerShadows. Therefore I've added the following mechanic:

Based on wether a `shadowInner` flag is provided with `styles` the generated shadow will be applied to `style.shadow` or `style.innerShadow`. Also the `_class` is calculated based on the existence of that flag.

Happy to discuss naming and if it makes sense/is possible to apply the same logic to the ImageRenderer.