### PR TITLE
Add glamorous example

### DIFF
--- a/examples/glamorous/README.md
+++ b/examples/glamorous/README.md
@@ -1,0 +1,27 @@
+# glamorous 💄
+
+## How to use
+Download the example or [clone the repo](http://github.com/airbnb/react-sketchapp):
+```
+curl https://codeload.github.com/airbnb/react-sketchapp/tar.gz/master | tar -xz --strip=2 react-sketchapp-master/examples/glamorous
+cd glamorous
+```
+
+Install the dependencies
+```
+npm install
+```
+
+### Run it in Sketch
+Run with live reloading in Sketch
+```
+npm run render
+```
+
+Or, to install as a Sketch plugin:
+```
+npm run build
+npm run link-plugin
+```
+
+Then, open Sketch and navigate to `Plugins → react-sketchapp: glamorous`

--- a/examples/glamorous/package.json
+++ b/examples/glamorous/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "glamorous-example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "glamorous.sketchplugin",
+  "manifest": "src/manifest.json",
+  "scripts": {
+    "build": "skpm build",
+    "watch": "skpm build --watch",
+    "render": "skpm build --watch --run",
+    "render:once": "skpm build --run",
+    "link-plugin": "skpm link"
+  },
+  "author": "Nitin Tulswani <tulswani19@gmail.com>",
+  "license": "MIT",
+  "devDependencies": {
+    "skpm": "^0.10.5"
+  },
+  "dependencies": {
+    "chroma-js": "^1.3.4",
+    "glamorous-primitives": "^2.1.0",
+    "react": "^15.6.1",
+    "react-sketchapp": "^0.12.1",
+    "react-test-renderer": "^15.6.1"
+  }
+}

--- a/examples/glamorous/src/manifest.json
+++ b/examples/glamorous/src/manifest.json
@@ -1,0 +1,17 @@
+{
+	"compatibleVersion": 3,
+	"bundleVersion": 1,
+	"commands": [
+		{
+			"name": "react-sketchapp: glamorous",
+			"identifier": "main",
+			"script": "./my-command.js"
+		}
+	],
+	"menu": {
+		"isRoot": true,
+		"items": [
+			"main"
+		]
+	}
+}

--- a/examples/glamorous/src/my-command.js
+++ b/examples/glamorous/src/my-command.js
@@ -1,36 +1,40 @@
 import React from 'react';
 import glamorous from 'glamorous-primitives';
 import { render } from 'react-sketchapp';
-import chroma from 'chroma-js';
 
 const Container = glamorous.view({
-	display: 'flex',
-	justifyContent: 'center',
-	alignItems: 'center',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
 });
 
 const Image = glamorous.image({
-	width: 400,
-	height: 400,
+  width: 400,
+  height: 400,
 });
 
 const Description = glamorous.text({
-	fontSize: 35,
-	padding: 40,
-	color: '#a4a4c1',
+  fontSize: 35,
+  padding: 40,
+  color: '#a4a4c1',
 });
 
 class App extends React.Component {
-	render() {
-		return (
-			<Container>
-				<Image source={{ uri: 'https://github.com/paypal/glamorous/raw/master/other/logo/full.png' }} />
-				<Description>Maintainable CSS with React</Description>
-			</Container>
-		);
-	}
+  render() {
+    return (
+      <Container>
+        <Image
+          source={{
+            uri:
+              'https://github.com/paypal/glamorous/raw/master/other/logo/full.png',
+          }}
+        />
+        <Description>Maintainable CSS with React</Description>
+      </Container>
+    );
+  }
 }
 
-export default context => {
-	render(<App />, context.document.currentPage());
+export default (context) => {
+  render(<App />, context.document.currentPage());
 };

--- a/examples/glamorous/src/my-command.js
+++ b/examples/glamorous/src/my-command.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import glamorous from 'glamorous-primitives';
+import { render } from 'react-sketchapp';
+import chroma from 'chroma-js';
+
+const Container = glamorous.view({
+	display: 'flex',
+	justifyContent: 'center',
+	alignItems: 'center',
+});
+
+const Image = glamorous.image({
+	width: 400,
+	height: 400,
+});
+
+const Description = glamorous.text({
+	fontSize: 35,
+	padding: 40,
+	color: '#a4a4c1',
+});
+
+class App extends React.Component {
+	render() {
+		return (
+			<Container>
+				<Image source={{ uri: 'https://github.com/paypal/glamorous/raw/master/other/logo/full.png' }} />
+				<Description>Maintainable CSS with React</Description>
+			</Container>
+		);
+	}
+}
+
+export default context => {
+	render(<App />, context.document.currentPage());
+};


### PR DESCRIPTION
With the release of [glamorous](https://github.com/paypal/glamorous) v4, we have now support for styling primitive React interfaces using [glamorous-primitives](https://github.com/nitin42/glamorous-primitives) which means it can also be used with `react-sketchapp` 🎉 