### PR TITLE
Documentation for symbols (Issue #112)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -21,6 +21,9 @@
 * [`TextStyles`](#textstyles)
   * [`create`](#createstyleoptionsstyles)
   * [`resolve`](#resolvestyle)
+* [`Symbols`](#symbols)
+  * [`makeSymbol`](#makesymbolnode-name)
+  * [`injectSymbols`](#injectsymbols)
 
 ### `render(element, container)`
 Returns the top-level rendered Sketch object.
@@ -370,3 +373,187 @@ export default (context) => {
 
 ### `clear`
 Reset the registered styles.
+
+## Symbols
+An interface to Sketch's symbols. Create symbols and optionally inject them into the symbols page.
+
+### `makeSymbol(node, name)`
+Returns a Sketch symbol given a node and an optional name.
+
+#### Parameters
+| Parameter | Type | Default | Note |
+|---|---|---|---|
+| `node` | `Node` | | The node object that will be rendered as a symbol |
+| `name` | `String` | The node name | Optional name for the symbol, string can include backslashes to organise these symbols with Sketch. For example `squares/blue` |
+
+#### Symbol example
+```js
+const BlueSquare = () => (
+  <View
+    name="Blue Square"
+    style={{ width: 100, height: 100, backgroundColor: 'blue' }}
+  />
+);
+
+const BlueSquareSymbol = makeSymbol(BlueSquare);
+
+const Document = () => (
+  <Artboard>
+    <BlueSquareSymbol />
+  </Artboard>
+);
+
+export default (context) => {
+  render(<Document />, context.document.currentPage());
+}
+```
+
+#### Text override example
+Text overrides use the name paramater to target a specific Text primitive. When no name is given the value within the Text primitive can be used to override the value.
+
+```js
+const BlueSquare = () => (
+  <View
+    name="Blue Square"
+    style={{ width: 100, height: 100, backgroundColor: 'blue' }}
+  >
+    <Text>Blue Square Text</Text>
+  </View>
+);
+
+const BlueSquareSymbol = makeSymbol(BlueSquare, 'squares/blue');
+
+const Document = () => (
+  <Artboard>
+    <BlueSquareSymbol overrides={{
+      'Blue Square Text': 'Override Text',
+    }} />
+  </Artboard>
+);
+
+export default (context) => {
+  render(<Document />, context.document.currentPage());
+}
+```
+
+#### Image override example
+Image overrides use the name paramater to target a specific Image primitive.
+
+```js
+const BlueSquare = () => (
+  <View
+    name="Blue Square"
+    style={{ width: 100, height: 100, backgroundColor: 'blue' }}
+  >
+    <Image name="Blue Square Image" source="https://hello.world/image.jpg" />
+  </View>
+);
+
+const BlueSquareSymbol = makeSymbol(BlueSquare, 'squares/blue');
+
+const Document = () => (
+  <Artboard>
+    <BlueSquareSymbol overrides={{
+      'Blue Square Image': 'https://hello.world/different.jpg',
+    }} />
+  </Artboard>
+);
+
+export default (context) => {
+  render(<Document />, context.document.currentPage());
+}
+```
+
+#### Nested symbol + override example
+
+```js
+const RedSquare = () => (
+  <View
+    name="Red Square"
+    style={{ width: 100, height: 100, backgroundColor: 'red' }}
+  >
+    <Text name="Red Square Text">Red Square</Text>
+  </View>
+);
+
+const RedSquareSymbol = makeSymbol(RedSquare, 'squares/red');
+
+const BlueSquare = () => (
+  <View
+    name="Blue Square"
+    style={{ width: 100, height: 100, backgroundColor: 'blue' }}
+  >
+    <Text name="Blue Square Text">Blue Square</Text>
+  </View>
+);
+
+const BlueSquareSymbol = makeSymbol(BlueSquare, 'squares/blue');
+
+const Photo = () => (
+  <Image
+    name="Photo"
+    source="https://pbs.twimg.com/profile_images/756488692135526400/JUCawBiW_400x400.jpg"
+    style={{ width: 100, height: 100 }}
+  />
+);
+
+const PhotoSymbol = makeSymbol(Photo);
+
+const Nested = () => (
+  <View
+    name="Nested"
+    style={{ display: 'flex', flexDirection: 'column', width: 75, height: 150 }}
+  >
+    <PhotoSymbol name="Photo Instance" style={{ width: 75, height: 75 }} />
+    <RedSquareSymbol
+      name="Red Square Instance"
+      style={{ width: 75, height: 75 }}
+    />
+  </View>
+);
+
+const NestedSymbol = makeSymbol(Nested);
+
+const Document = () => (
+  <Artboard style={{ display: 'flex' }}>
+    <NestedSymbol
+      name="Nested Symbol"
+      style={{ width: 75, height: 150 }}
+      overrides={{
+        'Red Square Instance': BlueSquareSymbol,
+        'Blue Square Text': 'Text override',
+        Photo: 'https://pbs.twimg.com/profile_images/833785170285178881/loBb32g3.jpg',
+      }}
+    />
+  </Artboard>
+);
+
+export default (context) => {
+  render(<Document />, context.document.currentPage());
+}
+```
+
+### `injectSymbols(node, name)`
+Injects the symbols into Sketch's symbol page. **Call this before rendering**.
+
+```js
+const BlueSquare = () => (
+  <View
+    name="Blue Square"
+    style={{ width: 100, height: 100, backgroundColor: 'blue' }}
+  />
+);
+
+const BlueSquareSymbol = makeSymbol(BlueSquare);
+
+const Document = () => (
+  <Artboard>
+    <BlueSquareSymbol />
+  </Artboard>
+);
+
+export default (context) => {
+  injectSymbols(context);
+  render(<Document />, context.document.currentPage());
+}
+```

--- a/docs/API.md
+++ b/docs/API.md
@@ -533,7 +533,7 @@ export default (context) => {
 }
 ```
 
-### `injectSymbols(node, name)`
+### `injectSymbols(context)`
 Injects the symbols into Sketch's symbol page. **Call this before rendering**.
 
 ```js

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@
     * [Platform](/docs/API.md#platform)
     * [StyleSheet](/docs/API.md#stylesheet)
     * [TextStyles](/docs/API.md#textstyles)
+    * [Symbols](/docs/API.md#symbols)
 * [Change Log](/CHANGELOG.md)
 * [FAQ](/docs/FAQ.md)
 * [Contributing](/CONTRIBUTING.md)

--- a/src/jsonUtils/style.js
+++ b/src/jsonUtils/style.js
@@ -47,6 +47,7 @@ export const makeShadow = (style: ViewStyle): SJShadow => {
   const opacity = style.shadowOpacity !== undefined ? style.shadowOpacity : 1;
   const color = style.shadowColor || style.color || DEFAULT_SHADOW_COLOR;
   const radius = style.shadowRadius !== undefined ? style.shadowRadius : 1;
+  const spread = style.shadowSpread !== undefined ? style.shadowSpread : 0;
   const { width: offsetX = 0, height: offsetY = 0 } = style.shadowOffset || {};
 
   return {
@@ -61,7 +62,7 @@ export const makeShadow = (style: ViewStyle): SJShadow => {
     },
     offsetX,
     offsetY,
-    spread: 0,
+    spread,
   };
 };
 


### PR DESCRIPTION
I've added documentation on how to use symbols, this refers to issue #112.

The symbol documentation is divided in two sections, createSymbol and injectSymbols. The documentation includes examples for basic usage, text overrides, image overrides, nested symbols and how to inject the symbols into the symbols page.

Remarks are very welcome and I'm open to do some changes.