### PR TITLE
Fix Image primitive in Sketch 47

### DIFF
--- a/src/jsonUtils/hacksForJSONImpl.js
+++ b/src/jsonUtils/hacksForJSONImpl.js
@@ -92,7 +92,10 @@ export const makeImageDataFromUrl = (url: string): MSImageData => {
     image = NSImage.alloc().initWithData(fetchedData);
   }
 
-  return MSImageData.alloc().initWithImage_convertColorSpace(image, false);
+  if (MSImageData.alloc().initWithImage_convertColorSpace !== undefined) {
+    return MSImageData.alloc().initWithImage_convertColorSpace(image, false);
+  }
+  return MSImageData.alloc().initWithImage(image);
 };
 
 // This shouldn't need to call into Sketch, but it does currently, which is bad for perf :(


### PR DESCRIPTION
This is a fix for issue #173, it will remain backwards compatible with Sketch 46. 

@jongold how do we handle API changes from the Sketch side? Will we remove the check once 47 is released or will we remain backwards compatible.