### PR TITLE
Add Sketch 47+ Libraries Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prop-types": "^15.5.8",
     "sketch-constants": "^1.0.2",
     "sketchapp-json-flow-types": "^0.2.0",
-    "sketchapp-json-plugin": "^0.0.3"
+    "sketchapp-json-plugin": "^0.1.2"
   },
   "peerDependencies": {
     "react": "*",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prop-types": "^15.5.8",
     "sketch-constants": "^1.0.2",
     "sketchapp-json-flow-types": "^0.2.0",
-    "sketchapp-json-plugin": "^0.1.2"
+    "sketchapp-json-plugin": "^0.1.2",
     "yoga-layout": "1.6.0"
   },
   "peerDependencies": {

--- a/src/jsonUtils/models.js
+++ b/src/jsonUtils/models.js
@@ -34,6 +34,22 @@ function e7() {
   ]}${lut[(d3 >> 16) & 0xff]}${lut[(d3 >> 24) & 0xff]}`;
 }
 
+// Keep track on previous numbers that are generated
+let previousNumber = 1;
+
+// Will always produce a unique Number (Int) based on of the current date
+function generateIdNumber() {
+  let date = Date.now();
+
+  if (date <= previousNumber) {
+    date = previousNumber += 1;
+  } else {
+    previousNumber = date;
+  }
+
+  return date;
+}
+
 export function generateID(): string {
   return e7();
 }
@@ -153,6 +169,7 @@ export const makeSymbolMaster = (
   backgroundColor: makeColorFromCSS('white'),
   hasBackgroundColor: false,
   name,
+  changeIdentifier: generateIdNumber(),
   symbolID,
   frame,
 });


### PR DESCRIPTION
# Overview

This PR adds the ability to use the new Libraries feature in Sketch v47 ([Link](https://www.sketchapp.com/docs/libraries/))

# Changes

- Added new `changeIdentifier` property to the Symbol model.
  - This new property gets auto generated by a new `generateNumberId` function which ensures a unique Number (Int) by reading the current date and keeping track of previously generated numbers.

# Related Issues

https://github.com/airbnb/react-sketchapp/issues/172