### PR TITLE
Remove sketchapp-json-plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
     "NSDataBase64EncodingEndLineWithCarriageReturn": true,
     "NSData": true,
     "NSMakeRange": true,
+    "MSJSONDictionaryUnarchiver": true,
     "context": true
   },
   "rules": {
@@ -25,7 +26,7 @@
     "new-cap": 0,
     "no-duplicate-imports": [0],
     "react/prefer-stateless-function": 0,
-    "react/jsx-filename-extension": 0,
+    "react/jsx-filename-extension": 0
   },
   "env": {
     "node": true,

--- a/.jestrc
+++ b/.jestrc
@@ -56,6 +56,7 @@
     "React$Element": true,
     "ReactClass": true,
     "ReactComponent": true,
+    "MSJSONDictionaryUnarchiver": true,
     "context": true
   }
 }

--- a/__tests__/sharedStyles/TextStyles.js
+++ b/__tests__/sharedStyles/TextStyles.js
@@ -5,10 +5,9 @@ let sharedTextStyles;
 
 beforeEach(() => {
   jest.resetModules();
-  jest.mock('sketchapp-json-plugin', () => ({
-    appVersionSupported: jest.fn(() => true),
-    fromSJSONDictionary: jest.fn(),
-    toSJSON: jest.fn(),
+
+  jest.mock('../../src/utils/compat', () => ({
+    sketchVersionIsCompatible: jest.fn(() => true),
   }));
 
   TextStyles = require('../../src/sharedStyles/TextStyles').default;
@@ -30,7 +29,9 @@ describe('create', () => {
     it('it errors', () => {
       const styles = {};
 
-      expect(() => TextStyles.create({}, styles)).toThrowError(/Please provide a context/);
+      expect(() => TextStyles.create({}, styles)).toThrowError(
+        /Please provide a context/
+      );
     });
   });
 
@@ -41,7 +42,7 @@ describe('create', () => {
           clearExistingStyles: true,
           context,
         },
-        {},
+        {}
       );
 
       expect(sharedTextStyles.setStyles).toHaveBeenCalled();
@@ -53,7 +54,7 @@ describe('create', () => {
           clearExistingStyles: false,
           context,
         },
-        {},
+        {}
       );
       expect(sharedTextStyles.setStyles).not.toHaveBeenCalled();
     });
@@ -126,14 +127,14 @@ describe('create', () => {
           ...acc,
           [key]: true,
         }),
-        {},
+        {}
       );
 
       const res = TextStyles.create(
         {
           context,
         },
-        { foo: input },
+        { foo: input }
       );
 
       const firstStoredStyle = res[Object.keys(res)[0]].cssStyle;
@@ -155,7 +156,7 @@ describe('resolve', () => {
       {
         context,
       },
-      {},
+      {}
     );
   });
 

--- a/flow-typed/sketch.js
+++ b/flow-typed/sketch.js
@@ -53,5 +53,6 @@ declare var NSTextField: any;
 declare var NSTextView: any;
 declare var NSURL: any;
 declare var NSView: any;
+declare var MSJSONDictionaryUnarchiver: any;
 declare var log: any;
 declare var context: any;

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "normalize-css-color": "^1.0.1",
     "prop-types": "^15.5.8",
     "sketch-constants": "^1.0.2",
-    "sketchapp-json-flow-types": "^0.2.0",
-    "sketchapp-json-plugin": "^0.0.3"
+    "sketchapp-json-flow-types": "^0.2.0"
   },
   "peerDependencies": {
     "react": "*",

--- a/src/jsonUtils/convert.js
+++ b/src/jsonUtils/convert.js
@@ -15,12 +15,14 @@ export const SketchToJSObject = (sketchObj: SketchLayer): Object => {
 
 // Converts a JS Object tree into it's Sketch page object equivalent
 export const JSObjectToSketch = (jsTree: Object): SketchLayer => {
-  const decodedData = MSJSONDictionaryUnarchiver.unarchiveObjectFromDictionary_asVersion_corruptionDetected_error(
-    jsTree,
-    88, // 88 = Sketch v43+
-    null,
-    null
-  );
+  // prettier-ignore
+  const decodedData = MSJSONDictionaryUnarchiver
+    .unarchiveObjectFromDictionary_asVersion_corruptionDetected_error(
+      jsTree,
+      88, // 88 = Sketch v43+
+      null,
+      null
+    );
   const mutable = decodedData.class().mutableClass();
   return mutable.alloc().initWithImmutableModelObject(decodedData);
 };

--- a/src/jsonUtils/convert.js
+++ b/src/jsonUtils/convert.js
@@ -1,0 +1,32 @@
+// @flow
+import type { SketchLayer } from '../types';
+
+// Converts a Sketch page object into it's JSON equivalent
+export const SketchToJSON = (sketchObj: SketchLayer): string => {
+  const imm = sketchObj.immutableModelObject();
+  return MSJSONDataArchiver.archiveStringWithRootObject_error_(imm, null);
+};
+
+// Converts a Sketch page object into it's JS Object equivalent
+export const SketchToJSObject = (sketchObj: SketchLayer): Object => {
+  const json = SketchToJSON(sketchObj);
+  return JSON.parse(json);
+};
+
+// Converts a JS Object tree into it's Sketch page object equivalent
+export const JSObjectToSketch = (jsTree: Object): SketchLayer => {
+  const decoded = MSJSONDictionaryUnarchiver.unarchiveObjectFromDictionary_asVersion_corruptionDetected_error(
+    jsTree,
+    88, // 88 = Sketch v43
+    null,
+    null
+  );
+  const mutableClass = decoded.class().mutableClass();
+  return mutableClass.alloc().initWithImmutableModelObject(decoded);
+};
+
+// Converts a JSON tree into it's Sketch page object equivalent
+export const JSONToSketch = (jsonTree: string): SketchLayer => {
+  const jsTree = JSON.parse(jsonTree);
+  return JSObjectToSketch(jsTree);
+};

--- a/src/jsonUtils/convert.js
+++ b/src/jsonUtils/convert.js
@@ -1,5 +1,6 @@
 // @flow
 import type { SketchLayer } from '../types';
+import { SKETCH_LOWEST_COMPATIBLE_VERSION } from '../utils/constants';
 
 // Converts a Sketch page object into it's JSON equivalent
 export const SketchToJSON = (sketchObj: SketchLayer): string => {
@@ -19,7 +20,7 @@ export const JSObjectToSketch = (jsTree: Object): SketchLayer => {
   const decodedData = MSJSONDictionaryUnarchiver
     .unarchiveObjectFromDictionary_asVersion_corruptionDetected_error(
       jsTree,
-      88, // 88 = Sketch v43+
+      SKETCH_LOWEST_COMPATIBLE_VERSION,
       null,
       null
     );

--- a/src/jsonUtils/convert.js
+++ b/src/jsonUtils/convert.js
@@ -15,14 +15,14 @@ export const SketchToJSObject = (sketchObj: SketchLayer): Object => {
 
 // Converts a JS Object tree into it's Sketch page object equivalent
 export const JSObjectToSketch = (jsTree: Object): SketchLayer => {
-  const decoded = MSJSONDictionaryUnarchiver.unarchiveObjectFromDictionary_asVersion_corruptionDetected_error(
+  const decodedData = MSJSONDictionaryUnarchiver.unarchiveObjectFromDictionary_asVersion_corruptionDetected_error(
     jsTree,
-    88, // 88 = Sketch v43
+    88, // 88 = Sketch v43+
     null,
     null
   );
-  const mutableClass = decoded.class().mutableClass();
-  return mutableClass.alloc().initWithImmutableModelObject(decoded);
+  const mutable = decodedData.class().mutableClass();
+  return mutable.alloc().initWithImmutableModelObject(decodedData);
 };
 
 // Converts a JSON tree into it's Sketch page object equivalent

--- a/src/jsonUtils/hacksForJSONImpl.js
+++ b/src/jsonUtils/hacksForJSONImpl.js
@@ -2,10 +2,10 @@
 // We need native macOS fonts and colors for these hacks so import the old utils
 import type { SJTextStyle } from 'sketchapp-json-flow-types';
 import { TextAlignment } from 'sketch-constants';
-import { toSJSON } from 'sketchapp-json-plugin';
 import findFont from '../utils/findFont';
 import type { TextStyle } from '../types';
 import { generateID, makeColorFromCSS } from './models';
+import { SketchToJSObject } from './convert';
 
 export const TEXT_ALIGN = {
   auto: TextAlignment.Left,
@@ -35,13 +35,6 @@ export const TEXT_TRANSFORM = {
   none: 0,
   capitalize: 0,
 };
-
-// NOTE(gold): toSJSON doesn't recursively parse JS objects
-// https://github.com/airbnb/react-sketchapp/pull/73#discussion_r108529703
-function encodeSketchJSON(sketchObj) {
-  const encoded = toSJSON(sketchObj);
-  return JSON.parse(encoded);
-}
 
 function makeParagraphStyle(textStyle) {
   const pStyle = NSMutableParagraphStyle.alloc().init();
@@ -134,7 +127,7 @@ export function makeAttributedString(string: ?string, textStyle: TextStyle) {
     attribStr
   );
 
-  return encodeSketchJSON(msAttribStr);
+  return SketchToJSObject(msAttribStr);
 }
 
 export function makeTextStyle(textStyle: TextStyle) {
@@ -147,8 +140,8 @@ export function makeTextStyle(textStyle: TextStyle) {
   const value: SJTextStyle = {
     _class: 'textStyle',
     encodedAttributes: {
-      MSAttributedStringFontAttribute: encodeSketchJSON(font.fontDescriptor()),
-      NSColor: encodeSketchJSON(
+      MSAttributedStringFontAttribute: SketchToJSObject(font.fontDescriptor()),
+      NSColor: SketchToJSObject(
         NSColor.colorWithDeviceRed_green_blue_alpha(
           color.red,
           color.green,
@@ -156,7 +149,7 @@ export function makeTextStyle(textStyle: TextStyle) {
           color.alpha
         )
       ),
-      NSParagraphStyle: encodeSketchJSON(pStyle),
+      NSParagraphStyle: SketchToJSObject(pStyle),
       NSKern: textStyle.letterSpacing || 0,
       MSAttributedStringTextTransformAttribute:
         TEXT_TRANSFORM[textStyle.textTransform || 'initial'] * 1,

--- a/src/render.js
+++ b/src/render.js
@@ -1,15 +1,13 @@
 import React from 'react';
 import type { SJLayer } from 'sketchapp-json-flow-types';
-import {
-  appVersionSupported,
-  fromSJSONDictionary,
-} from 'sketchapp-json-plugin';
 import buildTree from './buildTree';
 import flexToSketchJSON from './flexToSketchJSON';
 import { resetDocument, resetPage } from './resets';
 import { getSymbolsPage } from './symbol';
 
 import type { SketchLayer, TreeNode } from './types';
+import { JSObjectToSketch } from './jsonUtils/convert';
+import { sketchVersionIsCompatible } from './utils/compat';
 import RedBox from './components/RedBox';
 
 export const renderToJSON = (element: React$Element<any>): SJLayer => {
@@ -36,7 +34,7 @@ const renderToSketch = (
   container: SketchLayer
 ): SketchLayer => {
   const json = flexToSketchJSON(node);
-  const layer = fromSJSONDictionary(json);
+  const layer = JSObjectToSketch(json);
 
   return renderLayers([layer], container);
 };
@@ -118,7 +116,7 @@ export const render = (
   element: React$Element<any>,
   container?: ?SketchLayer
 ): ?SketchLayer | Array<?SketchLayer> => {
-  if (appVersionSupported()) {
+  if (sketchVersionIsCompatible()) {
     try {
       // Clear out document to prepare for re-render
       resetDocument();

--- a/src/sharedStyles/TextStyles.js
+++ b/src/sharedStyles/TextStyles.js
@@ -1,8 +1,9 @@
 /* @flow */
 import invariant from 'invariant';
-import { appVersionSupported } from 'sketchapp-json-plugin';
 import type { SJStyle } from 'sketchapp-json-flow-types';
 import type { SketchContext, SketchStyle, TextStyle } from '../types';
+import { sketchVersionIsCompatible } from '../utils/compat';
+import { SKETCH_VERSION_COMPATIBILITY } from '../utils/constants';
 import hashStyle from '../utils/hashStyle';
 import sharedTextStyles from '../wrappers/sharedTextStyles';
 import { makeTextStyle } from '../jsonUtils/hacksForJSONImpl';
@@ -33,7 +34,7 @@ type RegisteredStyle = {|
   cssStyle: TextStyle,
   name: string,
   sketchStyle: SJStyle,
-  sharedObjectID: SketchObjectID,
+  sharedObjectID: SketchObjectID
 |};
 
 let _styles: StyleHash = {};
@@ -58,17 +59,22 @@ const registerStyle = (name: string, style: TextStyle): void => {
 
 type Options = {
   clearExistingStyles?: boolean,
-  context: SketchContext,
+  context: SketchContext
 };
 
-const create = (options: Options, styles: { [key: string]: TextStyle }): StyleHash => {
+const create = (
+  options: Options,
+  styles: { [key: string]: TextStyle }
+): StyleHash => {
   const { clearExistingStyles, context } = options;
 
-  if (!appVersionSupported()) {
-    return context.document.showMessage('💎 Requires Sketch 43+ 💎');
-  }
-
   invariant(options && options.context, 'Please provide a context');
+
+  if (!sketchVersionIsCompatible()) {
+    return context.document.showMessage(
+      `💎 Requires Sketch ${SKETCH_VERSION_COMPATIBILITY}+ 💎`
+    );
+  }
 
   sharedTextStyles.setContext(context);
 

--- a/src/sharedStyles/TextStyles.js
+++ b/src/sharedStyles/TextStyles.js
@@ -3,7 +3,7 @@ import invariant from 'invariant';
 import type { SJStyle } from 'sketchapp-json-flow-types';
 import type { SketchContext, SketchStyle, TextStyle } from '../types';
 import { sketchVersionIsCompatible } from '../utils/compat';
-import { SKETCH_APP_LOWEST_COMPATIBLE_VERSION } from '../utils/constants';
+import { SKETCH_LOWEST_COMPATIBLE_APP_VERSION } from '../utils/constants';
 import hashStyle from '../utils/hashStyle';
 import sharedTextStyles from '../wrappers/sharedTextStyles';
 import { makeTextStyle } from '../jsonUtils/hacksForJSONImpl';
@@ -72,7 +72,7 @@ const create = (
 
   if (!sketchVersionIsCompatible()) {
     return context.document.showMessage(
-      `💎 Requires Sketch ${SKETCH_APP_LOWEST_COMPATIBLE_VERSION}+ 💎`
+      `💎 Requires Sketch ${SKETCH_LOWEST_COMPATIBLE_APP_VERSION}+ 💎`
     );
   }
 

--- a/src/sharedStyles/TextStyles.js
+++ b/src/sharedStyles/TextStyles.js
@@ -3,7 +3,7 @@ import invariant from 'invariant';
 import type { SJStyle } from 'sketchapp-json-flow-types';
 import type { SketchContext, SketchStyle, TextStyle } from '../types';
 import { sketchVersionIsCompatible } from '../utils/compat';
-import { SKETCH_VERSION_COMPATIBILITY } from '../utils/constants';
+import { SKETCH_APP_LOWEST_COMPATIBLE_VERSION } from '../utils/constants';
 import hashStyle from '../utils/hashStyle';
 import sharedTextStyles from '../wrappers/sharedTextStyles';
 import { makeTextStyle } from '../jsonUtils/hacksForJSONImpl';
@@ -72,7 +72,7 @@ const create = (
 
   if (!sketchVersionIsCompatible()) {
     return context.document.showMessage(
-      `💎 Requires Sketch ${SKETCH_VERSION_COMPATIBILITY}+ 💎`
+      `💎 Requires Sketch ${SKETCH_APP_LOWEST_COMPATIBLE_VERSION}+ 💎`
     );
   }
 

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import type { SJSymbolMaster } from 'sketchapp-json-flow-types';
-import { fromSJSONDictionary, toSJSON } from 'sketchapp-json-plugin';
 import StyleSheet from './stylesheet';
 import { generateID } from './jsonUtils/models';
 import ViewStylePropTypes from './components/ViewStylePropTypes';
@@ -9,6 +8,7 @@ import buildTree from './buildTree';
 import flexToSketchJSON from './flexToSketchJSON';
 import { renderLayers } from './render';
 import { resetPage } from './resets';
+import { JSObjectToSketch, SketchToJSObject } from './jsonUtils/convert';
 
 let id = 0;
 const nextId = () => ++id; // eslint-disable-line
@@ -46,9 +46,9 @@ export const getExistingSymbols = () => {
     }
 
     existingSymbols = msListToArray(symbolsPage.layers()).map((x) => {
-      const symbolJson = JSON.parse(toSJSON(x));
-      layers[symbolJson.symbolID] = x;
-      return symbolJson;
+      const symbol = SketchToJSObject(x);
+      layers[symbol.symbolID] = x;
+      return symbol;
     });
 
     mastersNameRegistry = {};
@@ -88,7 +88,7 @@ const injectSymbols = () => {
     symbolMaster.frame.x = left;
     left += symbolMaster.frame.width + 20;
 
-    const newLayer = fromSJSONDictionary(symbolMaster);
+    const newLayer = JSObjectToSketch(symbolMaster);
     layers[symbolMaster.symbolID] = newLayer;
   });
 

--- a/src/utils/compat.js
+++ b/src/utils/compat.js
@@ -1,9 +1,9 @@
 // @flow
-import { SKETCH_VERSION_COMPATIBILITY } from './constants';
+import { SKETCH_APP_LOWEST_COMPATIBLE_VERSION } from './constants';
 
-// Verify Sketch version is compatible
+// Verify Sketch app version is compatible
 // eslint-disable-next-line
 export const sketchVersionIsCompatible = (): boolean => {
   const sketch = context.api();
-  return sketch._metadata.appVersion >= SKETCH_VERSION_COMPATIBILITY;
+  return sketch._metadata.appVersion >= SKETCH_APP_LOWEST_COMPATIBLE_VERSION;
 };

--- a/src/utils/compat.js
+++ b/src/utils/compat.js
@@ -1,0 +1,9 @@
+// @flow
+import { SKETCH_VERSION_COMPATIBILITY } from './constants';
+
+// Verify Sketch version is compatible
+// eslint-disable-next-line
+export const sketchVersionIsCompatible = (): boolean => {
+  const sketch = context.api();
+  return sketch._metadata.appVersion >= SKETCH_VERSION_COMPATIBILITY;
+};

--- a/src/utils/compat.js
+++ b/src/utils/compat.js
@@ -1,9 +1,9 @@
 // @flow
-import { SKETCH_APP_LOWEST_COMPATIBLE_VERSION } from './constants';
+import { SKETCH_LOWEST_COMPATIBLE_APP_VERSION } from './constants';
 
 // Verify Sketch app version is compatible
 // eslint-disable-next-line
 export const sketchVersionIsCompatible = (): boolean => {
   const sketch = context.api();
-  return sketch._metadata.appVersion >= SKETCH_APP_LOWEST_COMPATIBLE_VERSION;
+  return sketch._metadata.appVersion >= SKETCH_LOWEST_COMPATIBLE_APP_VERSION;
 };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -8,3 +8,5 @@ export const PatternFillType = {
   Stretch: 2,
   Fit: 3,
 };
+
+export const SKETCH_VERSION_COMPATIBILITY = '43';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -9,4 +9,8 @@ export const PatternFillType = {
   Fit: 3,
 };
 
-export const SKETCH_VERSION_COMPATIBILITY = '43';
+// More info on Sketch Build numbers: http://sketchplugins.com/d/316-sketch-version
+// Public Sketh App Version
+export const SKETCH_APP_LOWEST_COMPATIBLE_VERSION = '43';
+// Internal Sketch Version
+export const SKETCH_LOWEST_COMPATIBLE_VERSION = '88';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -11,6 +11,6 @@ export const PatternFillType = {
 
 // More info on Sketch Build numbers: http://sketchplugins.com/d/316-sketch-version
 // Public Sketh App Version
-export const SKETCH_APP_LOWEST_COMPATIBLE_VERSION = '43';
+export const SKETCH_LOWEST_COMPATIBLE_APP_VERSION = '43';
 // Internal Sketch Version
 export const SKETCH_LOWEST_COMPATIBLE_VERSION = '88';

--- a/src/wrappers/sharedTextStyles.js
+++ b/src/wrappers/sharedTextStyles.js
@@ -1,8 +1,8 @@
 /* @flow */
 import invariant from 'invariant';
-import { fromSJSONDictionary } from 'sketchapp-json-plugin';
 import type { SJStyle } from 'sketchapp-json-flow-types';
 import type { SketchContext } from '../types';
+import { JSObjectToSketch } from '../jsonUtils/convert';
 
 class TextStyles {
   _context: ?SketchContext;
@@ -21,7 +21,10 @@ class TextStyles {
   setStyles(styles: Array<any>) {
     invariant(this._context, 'Please provide a context');
 
-    this._context.document.documentData().layerTextStyles().setObjects(styles);
+    this._context.document
+      .documentData()
+      .layerTextStyles()
+      .setObjects(styles);
 
     return this;
   }
@@ -29,7 +32,7 @@ class TextStyles {
   addStyle(name: string, style: SJStyle) {
     invariant(this._context, 'Please provide a context');
 
-    const textStyle = fromSJSONDictionary(style);
+    const textStyle = JSObjectToSketch(style);
 
     // Flow doesn't pick up invariant truthies
     const context: SketchContext = this._context;


### PR DESCRIPTION
# Overview

This PR removes the need for `sketchapp-json-plugin` and enables correct JSON parsing/injection for Sketch 44+ features like [Resize Constraints](https://www.sketchapp.com/docs/layer-basics/constraints/) and [Libraries](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=5&cad=rja&uact=8&ved=0ahUKEwiu0YLbirLWAhUl6YMKHQEcCQIQFghDMAQ&url=https%3A%2F%2Fsketchapp.com%2Fdocs%2Flibraries%2F&usg=AFQjCNG_if0CMUnOHzMkuRi_qwveq3Dzlw)

# Changes

- `sketchapp-json-plugin` has been removed. 
    - Functions that were used from this plugin have been replaced
        - `appVersionSupported` -> `sketchVersionIsCompatible`
        - `fromSJSONDictionary` -> `JSObjectToSketch`
        - `toSJSON` -> `SketchToJSObject`
    - Extra functions are also added specific for handling JSON
        - `SketchToJSON`
        - `JSONToSketch`

# Why?

`sketchapp-json-plugin` is an awesome project, but it does not support any Sketch 44+ JSON properties/features which is delaying a few open PRs (https://github.com/airbnb/react-sketchapp/pull/170 & https://github.com/airbnb/react-sketchapp/pull/180). Contributing to provide this needed functionality has proven difficult as the maintainer has been non-responsive for quite some time (See https://github.com/darknoon/sketchapp-json-plugin/pull/3). 

This PR will ensure the owners/contributors of this repository can move forward with Sketch changes much faster and with full control. It will also unblock the PRs I mentioned above.

# Relavent Discussions

https://github.com/airbnb/react-sketchapp/issues/172
https://github.com/airbnb/react-sketchapp/issues/150