### PR TITLE
Overhaul layout calculation (css-layout -> yoga-layout)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
     "NSDataBase64EncodingEndLineWithCarriageReturn": true,
     "NSData": true,
     "NSMakeRange": true,
+    "NSMutableAttributedString": true,
     "context": true
   },
   "rules": {

--- a/.jestrc
+++ b/.jestrc
@@ -53,6 +53,7 @@
     "NSTextView": true,
     "NSURL": true,
     "NSView": true,
+    "NSMutableAttributedString": true,
     "React$Component": true,
     "React$Element": true,
     "ReactClass": true,

--- a/.jestrc
+++ b/.jestrc
@@ -1,5 +1,6 @@
 {
   "testEnvironment": "node",
+  "browser": true,
   "testPathIgnorePatterns": [
     "/node_modules/",
     "<rootDir>/_book",

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+yoga-layout:platform=browser

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os: osx
+osx_image: xcode8.2
 language: node_js
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+compiler:
+  - clang
+  - gcc
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: node_js
-compiler:
-  - clang
-  - gcc
 cache:
   directories:
     - node_modules

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -17,6 +17,12 @@ describe('public API', () => {
   it('exports StyleSheet', () => {
     expect(ReactSketch.StyleSheet).toBeDefined();
   });
+  it('exports Document', () => {
+    expect(ReactSketch.Document).toBeDefined();
+  });
+  it('exports Page', () => {
+    expect(ReactSketch.Page).toBeDefined();
+  });
   it('exports Artboard', () => {
     expect(ReactSketch.Artboard).toBeDefined();
   });

--- a/__tests__/jsonUtils/computeTextTree.js
+++ b/__tests__/jsonUtils/computeTextTree.js
@@ -1,0 +1,42 @@
+import computeTextTree from '../../src/jsonUtils/computeTextTree';
+import Context from '../../src/utils/Context';
+
+// Example Text component tree
+const treeStub = {
+  type: 'text',
+  props: {
+    name: 'Swatch Hex',
+    style: {
+      color: '#636464',
+      zIndex: 1,
+    },
+  },
+  children: [
+    '#F3F4F4',
+    ' ',
+    {
+      type: 'text',
+      props: {
+        name: 'Text',
+        style: {
+          color: 'blue',
+        },
+      },
+      children: ['Hello World'],
+    },
+  ],
+};
+
+// Correct Output
+const treeFixture = [
+  { content: '#F3F4F4', textStyles: {} },
+  { content: ' ', textStyles: {} },
+  { content: 'Hello World', textStyles: { color: 'blue' } },
+];
+
+describe('Compute Text Tree', () => {
+  it('correctly handle Text nodes', () => {
+    const tree = computeTextTree(treeStub, new Context());
+    expect(tree).toEqual(treeFixture);
+  });
+});

--- a/__tests__/jsonUtils/computeYogaNode.js
+++ b/__tests__/jsonUtils/computeYogaNode.js
@@ -166,6 +166,38 @@ describe('Compute Yoga Node', () => {
     });
   });
 
+  it('correctly handles flex: 0, number', () => {
+    const stylesToTest = [{ flex: 1 }, { flex: 0 }];
+    const [numberNode, noneNode] = createYogaNodes(stylesToTest);
+
+    expect(numberNode.width).toEqual(0);
+    expect(noneNode.width).toEqual(0);
+  });
+
+  it('correctly handles flexGrow: 0, number', () => {
+    const stylesToTest = [{ flexGrow: 1 }, { flexGrow: 0 }];
+    const [numberNode, noneNode] = createYogaNodes(stylesToTest);
+
+    expect(numberNode.width).toEqual(0);
+    expect(noneNode.width).toEqual(0);
+  });
+
+  it('correctly handles flexShrink: 0, number', () => {
+    const stylesToTest = [{ flexShrink: 1 }, { flexShrink: 0 }];
+    const [numberNode, noneNode] = createYogaNodes(stylesToTest);
+
+    expect(numberNode.width).toEqual(0);
+    expect(noneNode.width).toEqual(0);
+  });
+
+  it('correctly handles flexBasis: 0, number', () => {
+    const stylesToTest = [{ flexBasis: 1 }, { flexBasis: 0 }];
+    const [numberNode, noneNode] = createYogaNodes(stylesToTest);
+
+    expect(numberNode.width).toEqual(0);
+    expect(noneNode.width).toEqual(0);
+  });
+
   it('correctly handles position: relative & absolute', () => {
     const stylesToTest = [
       { position: 'relative', left: 10 },

--- a/__tests__/jsonUtils/computeYogaNode.js
+++ b/__tests__/jsonUtils/computeYogaNode.js
@@ -1,0 +1,350 @@
+import * as yoga from 'yoga-layout';
+import computeYogaNode from '../../src/jsonUtils/computeYogaNode';
+
+const widthAndHeightStylesStub = {
+  width: 10,
+  height: 10,
+};
+
+const widthAndHeightStylesStubFixture = {
+  left: 0,
+  right: 0,
+  top: 0,
+  bottom: 0,
+  width: 10,
+  height: 10,
+};
+
+const createTreeNode = (style: { [key: string]: number | string }) => ({
+  props: {
+    style,
+  },
+});
+
+const createYogaNodes = (
+  styles: Array<{ [key: string]: number | string }>,
+  containerWidth: number,
+  containerHeight: number
+) => {
+  const yogaNodes = [];
+  styles.forEach((style) => {
+    const treeNode = createTreeNode(style);
+    const { node } = computeYogaNode(treeNode);
+    node.calculateLayout(
+      containerWidth || yoga.UNDEFINED,
+      containerHeight || yoga.UNDEFINED,
+      yoga.DIRECTION_LTR
+    );
+    yogaNodes.push(node.getComputedLayout());
+  });
+
+  return yogaNodes;
+};
+
+describe('Compute Yoga Node', () => {
+  it('correctly handles width: 0, auto, number', () => {
+    const stylesToTest = [{ width: 100 }, { width: 0 }, { width: 'auto' }];
+    const [numberNode, noneNode, autoNode] = createYogaNodes(stylesToTest);
+
+    expect(numberNode.width).toEqual(100);
+    expect(noneNode.width).toEqual(0);
+    expect(autoNode.width).toEqual(0);
+  });
+
+  it('correctly handles height: 0, auto, number', () => {
+    const stylesToTest = [{ height: 100 }, { height: 0 }, { height: 'auto' }];
+    const [numberNode, noneNode, autoNode] = createYogaNodes(stylesToTest);
+
+    expect(numberNode.height).toEqual(100);
+    expect(noneNode.height).toEqual(0);
+    expect(autoNode.height).toEqual(0);
+  });
+
+  it('correctly handles min-height: 0 & number', () => {
+    const stylesToTest = [{ minHeight: 100 }, { minHeight: 0 }];
+    const [numberNode, noneNode] = createYogaNodes(stylesToTest);
+
+    expect(numberNode.height).toEqual(100);
+    expect(noneNode.height).toEqual(0);
+  });
+
+  it('correctly handles max-height: 0 & number', () => {
+    const stylesToTest = [{ height: '100%', maxHeight: 100 }, { maxHeight: 0 }];
+    const [numberNode, noneNode] = createYogaNodes(stylesToTest, 500, 500);
+
+    expect(numberNode.height).toEqual(100);
+    expect(noneNode.height).toEqual(0);
+  });
+
+  it('correctly handles min-width: 0 & number', () => {
+    const stylesToTest = [{ minWidth: 100 }, { minWidth: 0 }];
+    const [numberNode, noneNode] = createYogaNodes(stylesToTest);
+
+    expect(numberNode.width).toEqual(100);
+    expect(noneNode.width).toEqual(0);
+  });
+
+  it('correctly handles max-width: 0 & number', () => {
+    const stylesToTest = [{ width: '100%', maxWidth: 100 }, { maxWidth: 0 }];
+    const [numberNode, noneNode] = createYogaNodes(stylesToTest, 500, 500);
+
+    expect(numberNode.width).toEqual(100);
+    expect(noneNode.width).toEqual(0);
+  });
+
+  it('correctly handles margin', () => {
+    const stylesToTest = [{ margin: 100 }, { margin: 0 }, { margin: 'auto' }];
+    const [numberNode, noneNode, autoNode] = createYogaNodes(stylesToTest);
+
+    expect(numberNode).toEqual({
+      left: 100,
+      right: 100,
+      top: 100,
+      bottom: 100,
+      width: 0,
+      height: 0,
+    });
+    expect(noneNode).toEqual({
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+    });
+    expect(autoNode).toEqual({
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+    });
+  });
+
+  it('correctly handles padding', () => {
+    const stylesToTest = [{ padding: 100 }, { padding: 0 }];
+    const [numberNode, noneNode] = createYogaNodes(stylesToTest);
+
+    expect(numberNode).toEqual({
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      width: 200,
+      height: 200,
+    });
+    expect(noneNode).toEqual({
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+    });
+  });
+
+  it('correctly handles border', () => {
+    const stylesToTest = [{ border: 10 }, { border: 0 }];
+    const [numberNode, noneNode] = createYogaNodes(stylesToTest);
+
+    expect(numberNode).toEqual({
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      width: 20,
+      height: 20,
+    });
+    expect(noneNode).toEqual({
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+    });
+  });
+
+  it('correctly handles position: relative & absolute', () => {
+    const stylesToTest = [
+      { position: 'relative', left: 10 },
+      { position: 'absolute', top: 10 },
+    ];
+    const [relativeNode, absoluteNode] = createYogaNodes(stylesToTest);
+
+    expect(relativeNode).toEqual({
+      left: 10,
+      right: 10,
+      top: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+    });
+    expect(absoluteNode).toEqual({
+      left: 0,
+      right: 0,
+      top: 10,
+      bottom: 10,
+      width: 0,
+      height: 0,
+    });
+  });
+
+  it('correctly handles display: flex & none', () => {
+    const stylesToTest = [
+      { display: 'flex', ...widthAndHeightStylesStub },
+      { display: 'none', width: 10, height: 10 },
+    ];
+    const [relativeNode, absoluteNode] = createYogaNodes(stylesToTest);
+
+    expect(relativeNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(absoluteNode).toEqual(widthAndHeightStylesStubFixture);
+  });
+
+  it('correctly handles overflow: visible, scroll, hidden', () => {
+    const stylesToTest = [
+      { overflow: 'visible', ...widthAndHeightStylesStub },
+      { overflow: 'scroll', ...widthAndHeightStylesStub },
+      { overflow: 'hidden', ...widthAndHeightStylesStub },
+    ];
+    const [visibleNode, scrollNode, hiddenNode] = createYogaNodes(stylesToTest);
+
+    expect(visibleNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(scrollNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(hiddenNode).toEqual(widthAndHeightStylesStubFixture);
+  });
+
+  it('correctly handles flexDirection', () => {
+    const stylesToTest = [
+      { flexDirection: 'row', ...widthAndHeightStylesStub },
+      { flexDirection: 'column', ...widthAndHeightStylesStub },
+      { flexDirection: 'row-reverse', ...widthAndHeightStylesStub },
+      { flexDirection: 'column-reverse', ...widthAndHeightStylesStub },
+    ];
+    const [rowNode, colNode, rowReverseNode, colReverseNode] = createYogaNodes(
+      stylesToTest
+    );
+
+    expect(rowNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(colNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(rowReverseNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(colReverseNode).toEqual(widthAndHeightStylesStubFixture);
+  });
+
+  it('correctly handles justifyContent', () => {
+    const stylesToTest = [
+      { justifyContent: 'flex-start', ...widthAndHeightStylesStub },
+      { justifyContent: 'flex-end', ...widthAndHeightStylesStub },
+      { justifyContent: 'center', ...widthAndHeightStylesStub },
+      { justifyContent: 'space-between', ...widthAndHeightStylesStub },
+      { justifyContent: 'space-around', ...widthAndHeightStylesStub },
+    ];
+    const [
+      startNode,
+      endNode,
+      centerNode,
+      spaceBetweenNode,
+      spaceAroundNode,
+    ] = createYogaNodes(stylesToTest);
+
+    expect(startNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(endNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(centerNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(spaceBetweenNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(spaceAroundNode).toEqual(widthAndHeightStylesStubFixture);
+  });
+
+  it('correctly handles alignContent', () => {
+    const stylesToTest = [
+      { alignContent: 'flex-start', ...widthAndHeightStylesStub },
+      { alignContent: 'flex-end', ...widthAndHeightStylesStub },
+      { alignContent: 'center', ...widthAndHeightStylesStub },
+      { alignContent: 'stretch', ...widthAndHeightStylesStub },
+      { alignContent: 'baseline', ...widthAndHeightStylesStub },
+      { alignContent: 'space-between', ...widthAndHeightStylesStub },
+      { alignContent: 'space-around', ...widthAndHeightStylesStub },
+      { alignContent: 'auto', ...widthAndHeightStylesStub },
+    ];
+    const [
+      startNode,
+      endNode,
+      centerNode,
+      stretchNode,
+      baselineNode,
+      spaceBetweenNode,
+      spaceAroundNode,
+      autoNode,
+    ] = createYogaNodes(stylesToTest);
+
+    expect(startNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(endNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(centerNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(stretchNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(baselineNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(spaceBetweenNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(spaceAroundNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(autoNode).toEqual(widthAndHeightStylesStubFixture);
+  });
+
+  it('correctly handles alignItems', () => {
+    const stylesToTest = [
+      { alignItems: 'flex-start', ...widthAndHeightStylesStub },
+      { alignItems: 'flex-end', ...widthAndHeightStylesStub },
+      { alignItems: 'center', ...widthAndHeightStylesStub },
+      { alignItems: 'stretch', ...widthAndHeightStylesStub },
+      { alignItems: 'baseline', ...widthAndHeightStylesStub },
+    ];
+    const [
+      startNode,
+      endNode,
+      centerNode,
+      stretchNode,
+      baselineNode,
+    ] = createYogaNodes(stylesToTest);
+
+    expect(startNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(endNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(centerNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(stretchNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(baselineNode).toEqual(widthAndHeightStylesStubFixture);
+  });
+
+  it('correctly handles alignSelf', () => {
+    const stylesToTest = [
+      { alignSelf: 'flex-start', ...widthAndHeightStylesStub },
+      { alignSelf: 'flex-end', ...widthAndHeightStylesStub },
+      { alignSelf: 'center', ...widthAndHeightStylesStub },
+      { alignSelf: 'stretch', ...widthAndHeightStylesStub },
+      { alignSelf: 'baseline', ...widthAndHeightStylesStub },
+    ];
+    const [
+      startNode,
+      endNode,
+      centerNode,
+      stretchNode,
+      baselineNode,
+    ] = createYogaNodes(stylesToTest);
+
+    expect(startNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(endNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(centerNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(stretchNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(baselineNode).toEqual(widthAndHeightStylesStubFixture);
+  });
+
+  it('correctly handles flexWrap', () => {
+    const stylesToTest = [
+      { flexWrap: 'no-wrap', ...widthAndHeightStylesStub },
+      { flexWrap: 'wrap', ...widthAndHeightStylesStub },
+      { flexWrap: 'wrap-reverse', ...widthAndHeightStylesStub },
+    ];
+    const [noWrapNode, wrapNode, wrapReverseNode] = createYogaNodes(
+      stylesToTest
+    );
+
+    expect(noWrapNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(wrapNode).toEqual(widthAndHeightStylesStubFixture);
+    expect(wrapReverseNode).toEqual(widthAndHeightStylesStubFixture);
+  });
+});

--- a/__tests__/jsonUtils/computeYogaNode.js
+++ b/__tests__/jsonUtils/computeYogaNode.js
@@ -145,7 +145,7 @@ describe('Compute Yoga Node', () => {
   });
 
   it('correctly handles border', () => {
-    const stylesToTest = [{ border: 10 }, { border: 0 }];
+    const stylesToTest = [{ borderWidth: 10 }, { borderWidth: 0 }];
     const [numberNode, noneNode] = createYogaNodes(stylesToTest);
 
     expect(numberNode).toEqual({

--- a/__tests__/jsonUtils/computeYogaTree.js
+++ b/__tests__/jsonUtils/computeYogaTree.js
@@ -1,0 +1,66 @@
+import * as yoga from 'yoga-layout';
+import computeYogaTree from '../../src/jsonUtils/computeYogaTree';
+import Context from '../../src/utils/Context';
+
+const treeRootStub = {
+  type: 'artboard',
+  props: {
+    style: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      width: 416,
+    },
+    name: 'Swatches',
+  },
+  children: [
+    {
+      type: 'view',
+      props: {
+        name: 'Swatch Haus',
+        style: {
+          backgroundColor: '#F3F4F4',
+          height: 96,
+          marginTop: 4,
+          marginRight: 4,
+          marginBottom: 4,
+          marginLeft: 4,
+          paddingTop: 8,
+          paddingRight: 8,
+          paddingBottom: 8,
+          paddingLeft: 8,
+          width: 96,
+        },
+      },
+    },
+  ],
+};
+
+computeYogaTree(treeRootStub, new Context());
+
+describe('Compute Yoga Tree', () => {
+  it('correctly create yoga nodes into layout tree', () => {
+    const yogaTree = computeYogaTree(treeRootStub, new Context());
+    yogaTree.calculateLayout(
+      yoga.UNDEFINED,
+      yoga.UNDEFINED,
+      yoga.DIRECTION_LTR
+    );
+    expect(yogaTree.getComputedLayout()).toEqual({
+      bottom: 0,
+      height: 104,
+      left: 0,
+      right: 0,
+      top: 0,
+      width: 416,
+    });
+
+    expect(yogaTree.getChild(0).getComputedLayout()).toEqual({
+      bottom: 4,
+      height: 96,
+      left: 4,
+      right: 4,
+      top: 4,
+      width: 96,
+    });
+  });
+});

--- a/__tests__/jsonUtils/hacksForJSONImpl.js
+++ b/__tests__/jsonUtils/hacksForJSONImpl.js
@@ -5,6 +5,10 @@ describe('API', () => {
     expect(hacks.makeImageDataFromUrl).toBeInstanceOf(Function);
   });
 
+  it('exports makeImageDataFromUrl', () => {
+    expect(hacks.createAttributedString).toBeInstanceOf(Function);
+  });
+
   it('exports makeEncodedAttributedString', () => {
     expect(hacks.makeEncodedAttributedString).toBeInstanceOf(Function);
   });

--- a/__tests__/jsonUtils/hacksForJSONImpl.js
+++ b/__tests__/jsonUtils/hacksForJSONImpl.js
@@ -5,8 +5,8 @@ describe('API', () => {
     expect(hacks.makeImageDataFromUrl).toBeInstanceOf(Function);
   });
 
-  it('exports makeAttributedString', () => {
-    expect(hacks.makeAttributedString).toBeInstanceOf(Function);
+  it('exports makeEncodedAttributedString', () => {
+    expect(hacks.makeEncodedAttributedString).toBeInstanceOf(Function);
   });
 
   it('exports makeTextStyle', () => {

--- a/__tests__/utils/isNullOrUndefined.js
+++ b/__tests__/utils/isNullOrUndefined.js
@@ -1,0 +1,21 @@
+import isNullOrUndefined from '../../src/utils/isNullOrUndefined';
+
+describe('isNullOrUndefined', () => {
+  it('correctly identify null', () => {
+    const shouldBeNull = isNullOrUndefined(null);
+
+    expect(shouldBeNull).toEqual(true);
+  });
+
+  it('correctly identify undefined', () => {
+    const shouldBeUndefined = isNullOrUndefined(undefined);
+
+    expect(shouldBeUndefined).toEqual(true);
+  });
+
+  it('correctly identify zero (0)', () => {
+    const shouldBeZero = isNullOrUndefined(0);
+
+    expect(shouldBeZero).toEqual(false);
+  });
+});

--- a/__tests__/utils/zIndex.js
+++ b/__tests__/utils/zIndex.js
@@ -1,0 +1,55 @@
+import zIndex from '../../src/utils/zIndex';
+
+const noZIndexNode = {
+  props: {
+    style: {
+      zIndex: 0,
+    },
+  },
+};
+
+const zIndexNode = {
+  props: {
+    style: {
+      zIndex: 1,
+    },
+  },
+};
+
+const fixureThatShouldBeSortedDifferently = [noZIndexNode, zIndexNode];
+const fixureThatShouldNotBeSortedDifferently = [noZIndexNode, noZIndexNode];
+
+describe('zIndex', () => {
+  it('correctly resort zIndex', () => {
+    const shouldBeResorted = zIndex(fixureThatShouldBeSortedDifferently);
+
+    expect(shouldBeResorted[0].props.style.zIndex).toEqual(1);
+  });
+
+  it('correctly resort zIndex (reversed)', () => {
+    const shouldBeResorted = zIndex(fixureThatShouldBeSortedDifferently, true);
+
+    expect(shouldBeResorted[0].props.style.zIndex).toEqual(0);
+  });
+
+  it('correctly add original index to returned objects ', () => {
+    const shouldBeResorted = zIndex(fixureThatShouldBeSortedDifferently);
+
+    expect(shouldBeResorted[0].oIndex).toEqual(1);
+  });
+
+  it('correctly resort zIndexes that are all the same', () => {
+    const shouldNotBeResorted = zIndex(fixureThatShouldNotBeSortedDifferently);
+
+    expect(shouldNotBeResorted[0].props.style.zIndex).toEqual(0);
+  });
+
+  it('correctly resort zIndexes that are all the same (reversed)', () => {
+    const shouldNotBeResorted = zIndex(
+      fixureThatShouldNotBeSortedDifferently,
+      true
+    );
+
+    expect(shouldNotBeResorted[0].props.style.zIndex).toEqual(0);
+  });
+});

--- a/docs/API.md
+++ b/docs/API.md
@@ -546,7 +546,7 @@ const BlueSquareSymbol = makeSymbol(BlueSquare, 'squares/blue');
 const Photo = () => (
   <Image
     name="Photo"
-    source="https://pbs.twimg.com/profile_images/756488692135526400/JUCawBiW_400x400.jpg"
+    source="https://pbs.twimg.com/profile_images/895665264464764930/7Mb3QtEB_400x400.jpg"
     style={{ width: 100, height: 100 }}
   />
 );

--- a/examples/basic-setup/package.json
+++ b/examples/basic-setup/package.json
@@ -20,7 +20,7 @@
     "chroma-js": "^1.2.2",
     "prop-types": "^15.5.8",
     "react": "^15.4.2",
-    "react-sketchapp": "file:../../",
+    "react-sketchapp": "^0.12.1",
     "react-test-renderer": "^15.4.2"
   }
 }

--- a/examples/basic-setup/package.json
+++ b/examples/basic-setup/package.json
@@ -20,7 +20,7 @@
     "chroma-js": "^1.2.2",
     "prop-types": "^15.5.8",
     "react": "^15.4.2",
-    "react-sketchapp": "^0.12.0",
+    "react-sketchapp": "file:../../",
     "react-test-renderer": "^15.4.2"
   }
 }

--- a/examples/form-validation/src/components/Button.js
+++ b/examples/form-validation/src/components/Button.js
@@ -1,11 +1,11 @@
 /* @flow */
 import React from 'react';
-import { Text } from 'react-primitives';
+import { Text, View } from 'react-primitives';
 import { spacing, colors, fontFamily } from '../designSystem';
 
 type Props = {
   label: string,
-  backgroundColor: string,
+  backgroundColor: string
 };
 
 const buttonStyle = {
@@ -13,17 +13,21 @@ const buttonStyle = {
   boxSizing: 'border-box',
   color: colors.White,
   cursor: 'pointer',
-  fontFamily,
-  fontWeight: 'bold',
   padding: spacing.Medium,
-  textAlign: 'center',
   width: 300,
 };
 
+const textStyle = {
+  color: colors.White,
+  fontFamily,
+  fontWeight: 'bold',
+  textAlign: 'center',
+};
+
 const Button = ({ label, backgroundColor }: Props) => (
-  <Text style={{ ...buttonStyle, backgroundColor }}>
-    {label}
-  </Text>
+  <View style={{ ...buttonStyle, backgroundColor }}>
+    <Text style={{ ...textStyle }}>{label}</Text>
+  </View>
 );
 
 export default Button;

--- a/examples/form-validation/src/components/TextBox/index.sketch.js
+++ b/examples/form-validation/src/components/TextBox/index.sketch.js
@@ -6,13 +6,15 @@ import styles from './style';
 type Props = {
   label: string,
   value: string,
-  children?: React$Element<any>,
+  children?: React$Element<any>
 };
 
 const TextBox = ({ label, value, children }: Props) => (
   <View style={styles.formElement}>
     <Text style={styles.label}>{label}</Text>
-    <View style={styles.textbox}>{value}</View>
+    <View style={styles.textbox}>
+      <Text>{value}</Text>
+    </View>
     {children}
   </View>
 );

--- a/examples/profile-cards-primitives/src/data.js
+++ b/examples/profile-cards-primitives/src/data.js
@@ -2,25 +2,31 @@ export default [
   {
     screen_name: 'mxstbr',
     name: 'Max Stoiber',
-    description: '⚛️ Makes styled-components, react-boilerplate, @KeystoneJS and CarteBlanche. ✌ Open source developer @thethinkmill. ☕ Speciality coffee geek, skier, traveller.',
+    description:
+      '⚛️ Makes styled-components, react-boilerplate, @KeystoneJS and CarteBlanche. ✌ Open source developer @thethinkmill. ☕ Speciality coffee geek, skier, traveller.',
     location: 'Vienna, Austria',
     url: 'mxstbr.com',
-    profile_image_url: 'https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg',
+    profile_image_url:
+      'https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg',
   },
   {
     name: '- ̗̀Jackie ̖́-',
     screen_name: 'jackiesaik',
-    description: 'Graphic designer, never won a spelling be. Toronto on weekdays. Go Home Lake on weekends. ╮ (. ● ᴗ ●.) ╭',
+    description:
+      'Graphic designer, never won a spelling be. Toronto on weekdays. Go Home Lake on weekends. ╮ (. ● ᴗ ●.) ╭',
     location: 'Toronto, ON',
     url: 'cargocollective.com/jackiesaik',
-    profile_image_url: 'https://pbs.twimg.com/profile_images/756488692135526400/JUCawBiW_400x400.jpg',
+    profile_image_url:
+      'https://pbs.twimg.com/profile_images/895665264464764930/7Mb3QtEB_400x400.jpg',
   },
   {
     screen_name: 'jongold',
     name: 'kerning man',
-    description: 'an equal command of technology and form • functional programming (oc)cultist • design tools @airbnbdesign',
+    description:
+      'an equal command of technology and form • functional programming (oc)cultist • design tools @airbnbdesign',
     location: 'California',
     url: 'weirdwideweb.jon.gold',
-    profile_image_url: 'https://pbs.twimg.com/profile_images/833785170285178881/loBb32g3.jpg',
+    profile_image_url:
+      'https://pbs.twimg.com/profile_images/833785170285178881/loBb32g3.jpg',
   },
 ];

--- a/examples/profile-cards-react-with-styles/src/main.js
+++ b/examples/profile-cards-react-with-styles/src/main.js
@@ -44,7 +44,7 @@ export default () => {
       location: 'Toronto, ON',
       url: 'cargocollective.com/jackiesaik',
       profile_image_url:
-        'https://pbs.twimg.com/profile_images/756488692135526400/JUCawBiW_400x400.jpg',
+        'https://pbs.twimg.com/profile_images/895665264464764930/7Mb3QtEB_400x400.jpg',
     },
     {
       screen_name: 'jongold',

--- a/examples/profile-cards/src/main.js
+++ b/examples/profile-cards/src/main.js
@@ -44,7 +44,7 @@ export default () => {
       location: 'Toronto, ON',
       url: 'cargocollective.com/jackiesaik',
       profile_image_url:
-        'https://pbs.twimg.com/profile_images/756488692135526400/JUCawBiW_400x400.jpg',
+        'https://pbs.twimg.com/profile_images/895665264464764930/7Mb3QtEB_400x400.jpg',
     },
     {
       screen_name: 'jongold',

--- a/examples/symbols/src/my-command.js
+++ b/examples/symbols/src/my-command.js
@@ -33,7 +33,7 @@ const BlueSquareSym = makeSymbol(BlueSquare, 'squares/blue');
 const Photo = () => (
   <Image
     name="Photo"
-    source="https://pbs.twimg.com/profile_images/756488692135526400/JUCawBiW_400x400.jpg"
+    source="https://pbs.twimg.com/profile_images/895665264464764930/7Mb3QtEB_400x400.jpg"
     style={{ width: 100, height: 100 }}
   />
 );

--- a/examples/symbols/src/my-command.js
+++ b/examples/symbols/src/my-command.js
@@ -41,10 +41,7 @@ const Photo = () => (
 const PhotoSym = makeSymbol(Photo);
 
 const Nested = () => (
-  <View
-    name="Multi"
-    style={{ display: 'flex', flexDirection: 'column', width: 75, height: 150 }}
-  >
+  <View name="Multi" style={{ display: 'flex', flexDirection: 'column' }}>
     <PhotoSym name="Photo Instance" style={{ width: 75, height: 75 }} />
     <RedSquareSym
       name="Red Square Instance"
@@ -60,7 +57,6 @@ export default () => {
     <Artboard name="Swatches" style={{ display: 'flex' }}>
       <NestedSym
         name="Nested Symbol"
-        style={{ width: 75, height: 150 }}
         overrides={{
           'Red Square Instance': BlueSquareSym,
           'Blue Square Text': 'TESTING',

--- a/flow-typed/sketch.js
+++ b/flow-typed/sketch.js
@@ -53,5 +53,6 @@ declare var NSTextField: any;
 declare var NSTextView: any;
 declare var NSURL: any;
 declare var NSView: any;
+declare var NSMutableAttributedString: any;
 declare var log: any;
 declare var context: any;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "watch": "npm run build:react -- --watch"
   },
   "dependencies": {
-    "css-layout": "^1.1.1",
     "error-stack-parser": "^2.0.0",
     "invariant": "^2.2.2",
     "murmur2js": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "prop-types": "^15.5.8",
     "sketch-constants": "^1.0.2",
     "sketchapp-json-flow-types": "^0.2.0",
-    "sketchapp-json-plugin": "^0.0.3"
+    "sketchapp-json-plugin": "^0.0.3",
+    "yoga-layout": "^1.6.0"
   },
   "peerDependencies": {
     "react": "*",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "test": "jest --config .jestrc",
     "test:ci": "jest --config .jestrc --runInBand",
     "test:watch": "npm run test -- --watch",
-    "watch": "npm run build:react -- --watch"
+    "watch": "npm run build:react -- --watch",
+    "postinstall": "npm run yogafix",
+    "yogafix": "node ./yogafix"
   },
   "dependencies": {
     "error-stack-parser": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "sketch-constants": "^1.0.2",
     "sketchapp-json-flow-types": "^0.2.0",
     "sketchapp-json-plugin": "^0.0.3",
-    "yoga-layout": "^1.6.0"
+    "yoga-layout": "1.6.0"
   },
   "peerDependencies": {
     "react": "*",

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -49,6 +49,10 @@ const reactTreeToFlexTree = (
 
     for (let index = 0; index < children.length; index += 1) {
       const childComponent = children[index];
+      const childStyles =
+        childComponent.props && childComponent.props.styles
+          ? childComponent.props.styles
+          : {};
 
       // Since we reversed the order of children and sorted by zIndex, we need
       // to keep track of a decrementing index using the original index of the
@@ -59,9 +63,7 @@ const reactTreeToFlexTree = (
       const decrementIndex =
         children.length -
         1 -
-        (childComponent.props.style.position === 'absolute'
-          ? index
-          : childComponent.oIndex);
+        (childStyles.position === 'absolute' ? index : childComponent.oIndex);
       const childNode = yogaNode.getChild(decrementIndex);
 
       const renderedChildComponent = reactTreeToFlexTree(

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -43,6 +43,9 @@ const reactTreeToFlexTree = (
 
   const style = node.props.style || {};
 
+  // If current node is a Text node, add text styles to Context to pass down to
+  // child nodes and pass along all current context styles
+  // else, just pass along all current context styles
   if (
     node.type === 'text' &&
     node.props.style &&

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -21,8 +21,14 @@ const reactTreeToFlexTree = (
   yogaNode: yoga.NodeInstance,
   context: Context
 ) => {
-  let textStyle;
+  let textNodes;
+  let textStyle = context.getInheritedStyles();
   const style = node.props.style || {};
+
+  const children = Array.isArray(node.children)
+    ? processChildren(node.children)
+    : null;
+  const newChildren = [];
 
   if (node.type === 'text') {
     // If current node is a Text node, add text styles to Context to pass down to
@@ -41,37 +47,9 @@ const reactTreeToFlexTree = (
       };
     }
 
-    // Handle Text Children
-    const textNodes = computeTextTree(node, context);
-    const layout = yogaNode ? yogaNode.getComputedLayout() : {};
-
-    return Object.assign({}, SKETCH_TREE_OBJECT_STUB, {
-      type: 'text',
-      style,
-      props: {
-        ...node.props,
-        textNodes,
-      },
-      layout: {
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-        width: layout.width || 0,
-        height: layout.height || 0,
-      },
-      textStyle,
-    });
-  }
-
-  textStyle = context.getInheritedStyles();
-
-  const children = Array.isArray(node.children)
-    ? processChildren(node.children)
-    : null;
-  const newChildren = [];
-
-  if (children && node.type !== 'text') {
+    // Compute Text Children
+    textNodes = computeTextTree(node, context);
+  } else if (children) {
     for (let index = 0; index < children.length; index += 1) {
       const childComponent = children[index];
       const childNode = yogaNode.getChild(index);
@@ -96,7 +74,10 @@ const reactTreeToFlexTree = (
       width: yogaNode.getComputedWidth(),
       height: yogaNode.getComputedHeight(),
     },
-    props: node.props,
+    props: {
+      ...node.props,
+      textNodes,
+    },
     children: newChildren,
   });
 };

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -4,7 +4,7 @@ import Context from './utils/Context';
 import type { TreeNode } from './types';
 import hasAnyDefined from './utils/hasAnyDefined';
 import pick from './utils/pick';
-import computeTree from './jsonUtils/computeTree';
+import computeYogaTree from './jsonUtils/computeYogaTree';
 import computeTextTree from './jsonUtils/computeTextTree';
 import { INHERITABLE_FONT_STYLES } from './utils/constants';
 import zIndex from './utils/zIndex';
@@ -41,18 +41,19 @@ const reactTreeToFlexTree = (
     // Compute Text Children
     textNodes = computeTextTree(node, context);
   } else if (node.children && node.children.length > 0) {
-    // Recursion reverses the render stacking order, this corrects that and
+    // Recursion reverses the render stacking order, this corrects that
     node.children.reverse();
 
     // Calculates zIndex order
-    const children = zIndex(node.children);
+    const children = zIndex(node.children, true);
 
     for (let index = 0; index < children.length; index += 1) {
       const childComponent = children[index];
 
-      // Since we reversed the order of node.children above, we need to keep
-      // track of a decrementing index to get the correct Yoga node
-      const decrementIndex = children.length - 1 - index;
+      // Since we reversed the order of children and sorted by zIndex, we need
+      // to keep track of a decrementing index using the original index of the
+      // TreeNode to get the correct nodes
+      const decrementIndex = children.length - 1 - childComponent.oIndex;
       const childNode = yogaNode.getChild(decrementIndex);
 
       const renderedChildComponent = reactTreeToFlexTree(
@@ -87,7 +88,7 @@ const reactTreeToFlexTree = (
 const buildTree = (element: React$Element<any>): TreeNode => {
   const renderer = TestRenderer.create(element);
   const json: TreeNode = renderer.toJSON();
-  const yogaNode = computeTree(json, new Context());
+  const yogaNode = computeYogaTree(json, new Context());
   yogaNode.calculateLayout(yoga.UNDEFINED, yoga.UNDEFINED, yoga.DIRECTION_LTR);
   const tree = reactTreeToFlexTree(json, yogaNode, new Context());
 

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -23,26 +23,6 @@ const reactTreeToFlexTree = (
   context: Context
 ) => {
   let textStyle;
-
-  // if (typeof node === 'string') {
-  //   textStyle = context.getInheritedStyles();
-  //   const layout = yogaNode ? yogaNode.getComputedLayout() : {};
-
-  // return Object.assign({}, SKETCH_TREE_OBJECT_STUB, {
-  //   type: 'text',
-  //   layout: {
-  //     left: 0,
-  //     right: 0,
-  //     top: 0,
-  //     bottom: 0,
-  //     width: layout.width || 0,
-  //     height: layout.height || 0,
-  //   },
-  //   textStyle,
-  //   value: node,
-  // });
-  // }
-
   const style = node.props.style || {};
 
   // If current node is a Text node, add text styles to Context to pass down to
@@ -92,7 +72,9 @@ const reactTreeToFlexTree = (
     return Object.assign({}, SKETCH_TREE_OBJECT_STUB, {
       type: 'text',
       style,
-      textNodes,
+      props: {
+        textNodes,
+      },
       layout: {
         left: 0,
         right: 0,

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -52,8 +52,16 @@ const reactTreeToFlexTree = (
 
       // Since we reversed the order of children and sorted by zIndex, we need
       // to keep track of a decrementing index using the original index of the
-      // TreeNode to get the correct nodes
-      const decrementIndex = children.length - 1 - childComponent.oIndex;
+      // TreeNode to get the correct layout.
+      // NOTE: position: absolute handles zIndexes outside of flex layout, so we
+      // need to use the current child index and not it's original index (from
+      // before zIndex sorting).
+      const decrementIndex =
+        children.length -
+        1 -
+        (childComponent.props.style.position === 'absolute'
+          ? index
+          : childComponent.oIndex);
       const childNode = yogaNode.getChild(decrementIndex);
 
       const renderedChildComponent = reactTreeToFlexTree(

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -25,25 +25,6 @@ const reactTreeToFlexTree = (
   let textStyle;
   const style = node.props.style || {};
 
-  // If current node is a Text node, add text styles to Context to pass down to
-  // child nodes and pass along all current context styles
-  // else, just pass along all current context styles
-  if (
-    node.type === 'text' &&
-    node.props.style &&
-    hasAnyDefined(style, INHERITABLE_FONT_STYLES)
-  ) {
-    const inheritableStyles = pick(style, INHERITABLE_FONT_STYLES);
-    inheritableStyles.flexDirection = 'row';
-    context.addInheritableStyles(inheritableStyles);
-    textStyle = {
-      ...context.getInheritedStyles(),
-      ...inheritableStyles,
-    };
-  } else {
-    textStyle = context.getInheritedStyles();
-  }
-
   if (node.type === 'text') {
     // If current node is a Text node, add text styles to Context to pass down to
     // child nodes.
@@ -64,15 +45,12 @@ const reactTreeToFlexTree = (
     // Handle Text Children
     const textNodes = computeTextTree(node, context);
     const layout = createStringMeasurer(textNodes)(0);
-    let value = '';
-    textNodes.forEach((textNode) => {
-      value += textNode.content;
-    });
 
     return Object.assign({}, SKETCH_TREE_OBJECT_STUB, {
       type: 'text',
       style,
       props: {
+        ...node.props,
         textNodes,
       },
       layout: {
@@ -84,7 +62,6 @@ const reactTreeToFlexTree = (
         height: layout.height || 0,
       },
       textStyle,
-      value,
     });
   }
 

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -5,6 +5,7 @@ import createStringMeasurer from './utils/createStringMeasurer';
 import type { TreeNode } from './types';
 import hasAnyDefined from './utils/hasAnyDefined';
 import pick from './utils/pick';
+import * as yoga from 'yoga-layout';
 
 const INHERITABLE_STYLES = [
   'color',
@@ -81,6 +82,7 @@ const buildTree = (element: React$Element<any>): TreeNode => {
   const json: TreeNode = renderer.toJSON();
   const tree = reactTreeToFlexTree(json, new Context());
   computeLayout(tree);
+  console.log(yoga);
 
   return tree;
 };

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -28,7 +28,13 @@ const allStringsOrNumbers = xs =>
 
 const processChildren = xs => (allStringsOrNumbers(xs) ? [xs.join('')] : xs);
 
-const reactTreeToFlexTree = (node, yogaNode, context) => {
+const reactTreeToFlexTree = (
+  node: TreeNode,
+  yogaNode: yoga.NodeInstance,
+  context: Context,
+  parentNode: ?TreeNode,
+  parentYogaNode: ?yoga.NodeInstance
+) => {
   const children = Array.isArray(node.children)
     ? processChildren(node.children)
     : [];
@@ -36,16 +42,20 @@ const reactTreeToFlexTree = (node, yogaNode, context) => {
 
   if (typeof node === 'string' || typeof node === 'number') {
     textStyle = context.getInheritedStyles();
+    // Grab parent node's details to make sure child text nodes match
+    const style = parentNode ? parentNode.props.style : {};
+    const layout = parentYogaNode ? parentYogaNode.getComputedLayout() : {};
+
     return {
       type: 'text',
-      style: {},
+      style,
       layout: {
         left: 0,
         right: 0,
         top: 0,
         bottom: 0,
-        width: 0,
-        height: 0,
+        width: layout.width || 0,
+        height: layout.height || 0,
       },
       textStyle,
       props: {},
@@ -89,7 +99,9 @@ const reactTreeToFlexTree = (node, yogaNode, context) => {
       reactTreeToFlexTree(
         child,
         yogaNode.getChild(index),
-        context.forChildren()
+        context.forChildren(),
+        node,
+        yogaNode
       )
     ),
   };

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -5,6 +5,8 @@ import type { TreeNode } from './types';
 import hasAnyDefined from './utils/hasAnyDefined';
 import pick from './utils/pick';
 import computeTree from './jsonUtils/computeTree';
+import createStringMeasurer from './utils/createStringMeasurer';
+import computeTextTree from './jsonUtils/computeTextTree';
 import {
   INHERITABLE_FONT_STYLES,
   SKETCH_TREE_OBJECT_STUB,
@@ -26,19 +28,19 @@ const reactTreeToFlexTree = (
   //   textStyle = context.getInheritedStyles();
   //   const layout = yogaNode ? yogaNode.getComputedLayout() : {};
 
-  //   return Object.assign({}, SKETCH_TREE_OBJECT_STUB, {
-  //     type: 'text',
-  //     layout: {
-  //       left: 0,
-  //       right: 0,
-  //       top: 0,
-  //       bottom: 0,
-  //       width: layout.width || 0,
-  //       height: layout.height || 0,
-  //     },
-  //     textStyle,
-  //     value: node,
-  //   });
+  // return Object.assign({}, SKETCH_TREE_OBJECT_STUB, {
+  //   type: 'text',
+  //   layout: {
+  //     left: 0,
+  //     right: 0,
+  //     top: 0,
+  //     bottom: 0,
+  //     width: layout.width || 0,
+  //     height: layout.height || 0,
+  //   },
+  //   textStyle,
+  //   value: node,
+  // });
   // }
 
   const style = node.props.style || {};
@@ -61,6 +63,50 @@ const reactTreeToFlexTree = (
   } else {
     textStyle = context.getInheritedStyles();
   }
+
+  if (node.type === 'text') {
+    // If current node is a Text node, add text styles to Context to pass down to
+    // child nodes.
+    if (
+      node.props &&
+      node.props.style &&
+      hasAnyDefined(style, INHERITABLE_FONT_STYLES)
+    ) {
+      const inheritableStyles = pick(style, INHERITABLE_FONT_STYLES);
+      inheritableStyles.flexDirection = 'row';
+      context.addInheritableStyles(inheritableStyles);
+      textStyle = {
+        ...context.getInheritedStyles(),
+        ...inheritableStyles,
+      };
+    }
+
+    // Handle Text Children
+    const textNodes = computeTextTree(node, context);
+    const layout = createStringMeasurer(textNodes)(0);
+    let value = '';
+    textNodes.forEach((textNode) => {
+      value += textNode.content;
+    });
+
+    return Object.assign({}, SKETCH_TREE_OBJECT_STUB, {
+      type: 'text',
+      style,
+      textNodes,
+      layout: {
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+        width: layout.width || 0,
+        height: layout.height || 0,
+      },
+      textStyle,
+      value,
+    });
+  }
+
+  textStyle = context.getInheritedStyles();
 
   const children = Array.isArray(node.children)
     ? processChildren(node.children)

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -7,6 +7,7 @@ import pick from './utils/pick';
 import computeTree from './jsonUtils/computeTree';
 import computeTextTree from './jsonUtils/computeTextTree';
 import { INHERITABLE_FONT_STYLES } from './utils/constants';
+import zIndex from './utils/zIndex';
 
 const reactTreeToFlexTree = (
   node: TreeNode,
@@ -40,15 +41,18 @@ const reactTreeToFlexTree = (
     // Compute Text Children
     textNodes = computeTextTree(node, context);
   } else if (node.children && node.children.length > 0) {
-    // Recursion reverses the render stacking order, this corrects that.
+    // Recursion reverses the render stacking order, this corrects that and
     node.children.reverse();
 
-    for (let index = 0; index < node.children.length; index += 1) {
-      const childComponent = node.children[index];
+    // Calculates zIndex order
+    const children = zIndex(node.children);
+
+    for (let index = 0; index < children.length; index += 1) {
+      const childComponent = children[index];
 
       // Since we reversed the order of node.children above, we need to keep
       // track of a decrementing index to get the correct Yoga node
-      const decrementIndex = node.children.length - 1 - index;
+      const decrementIndex = children.length - 1 - index;
       const childNode = yogaNode.getChild(decrementIndex);
 
       const renderedChildComponent = reactTreeToFlexTree(

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -22,24 +22,24 @@ const reactTreeToFlexTree = (
 ) => {
   let textStyle;
 
-  if (typeof node === 'string') {
-    textStyle = context.getInheritedStyles();
-    const layout = yogaNode ? yogaNode.getComputedLayout() : {};
+  // if (typeof node === 'string') {
+  //   textStyle = context.getInheritedStyles();
+  //   const layout = yogaNode ? yogaNode.getComputedLayout() : {};
 
-    return Object.assign({}, SKETCH_TREE_OBJECT_STUB, {
-      type: 'text',
-      layout: {
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-        width: layout.width || 0,
-        height: layout.height || 0,
-      },
-      textStyle,
-      value: node,
-    });
-  }
+  //   return Object.assign({}, SKETCH_TREE_OBJECT_STUB, {
+  //     type: 'text',
+  //     layout: {
+  //       left: 0,
+  //       right: 0,
+  //       top: 0,
+  //       bottom: 0,
+  //       width: layout.width || 0,
+  //       height: layout.height || 0,
+  //     },
+  //     textStyle,
+  //     value: node,
+  //   });
+  // }
 
   const style = node.props.style || {};
 
@@ -52,6 +52,7 @@ const reactTreeToFlexTree = (
     hasAnyDefined(style, INHERITABLE_FONT_STYLES)
   ) {
     const inheritableStyles = pick(style, INHERITABLE_FONT_STYLES);
+    inheritableStyles.flexDirection = 'row';
     context.addInheritableStyles(inheritableStyles);
     textStyle = {
       ...context.getInheritedStyles(),
@@ -66,7 +67,7 @@ const reactTreeToFlexTree = (
     : null;
   const newChildren = [];
 
-  if (children) {
+  if (children && node.type !== 'text') {
     for (let index = 0; index < children.length; index += 1) {
       const childComponent = children[index];
       const childNode = yogaNode.getChild(index);

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -1,7 +1,6 @@
 import TestRenderer from 'react-test-renderer';
 import * as yoga from 'yoga-layout';
 import Context from './utils/Context';
-import createStringMeasurer from './utils/createStringMeasurer';
 import type { TreeNode } from './types';
 import hasAnyDefined from './utils/hasAnyDefined';
 import pick from './utils/pick';
@@ -37,19 +36,16 @@ const reactTreeToFlexTree = (node, yogaNode, context) => {
 
   if (typeof node === 'string' || typeof node === 'number') {
     textStyle = context.getInheritedStyles();
-    const measure = createStringMeasurer(node, textStyle)();
     return {
       type: 'text',
-      style: {
-        measure,
-      },
+      style: {},
       layout: {
         left: 0,
         right: 0,
         top: 0,
         bottom: 0,
-        width: measure.width,
-        height: measure.height,
+        width: 0,
+        height: 0,
       },
       textStyle,
       props: {},

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -23,14 +23,15 @@ const reactTreeToFlexTree = (
 ) => {
   let textNodes;
   let textStyle = context.getInheritedStyles();
-  const style = node.props.style || {};
+  const style = node.props && node.props.style ? node.props.style : {};
+  const type = node.type || 'text';
 
   const children = Array.isArray(node.children)
     ? processChildren(node.children)
     : null;
   const newChildren = [];
 
-  if (node.type === 'text') {
+  if (type === 'text') {
     // If current node is a Text node, add text styles to Context to pass down to
     // child nodes.
     if (
@@ -63,7 +64,7 @@ const reactTreeToFlexTree = (
   }
 
   return Object.assign({}, SKETCH_TREE_OBJECT_STUB, {
-    type: node.type,
+    type,
     style,
     textStyle,
     layout: {

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -6,10 +6,7 @@ import hasAnyDefined from './utils/hasAnyDefined';
 import pick from './utils/pick';
 import computeTree from './jsonUtils/computeTree';
 import computeTextTree from './jsonUtils/computeTextTree';
-import {
-  INHERITABLE_FONT_STYLES,
-  SKETCH_TREE_OBJECT_STUB,
-} from './utils/constants';
+import { INHERITABLE_FONT_STYLES } from './utils/constants';
 
 const allStringsOrNumbers = xs =>
   xs.every(x => typeof x === 'string' || typeof x === 'number');
@@ -63,7 +60,7 @@ const reactTreeToFlexTree = (
     }
   }
 
-  return Object.assign({}, SKETCH_TREE_OBJECT_STUB, {
+  return {
     type,
     style,
     textStyle,
@@ -80,7 +77,7 @@ const reactTreeToFlexTree = (
       textNodes,
     },
     children: newChildren,
-  });
+  };
 };
 
 const buildTree = (element: React$Element<any>): TreeNode => {

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -5,7 +5,6 @@ import type { TreeNode } from './types';
 import hasAnyDefined from './utils/hasAnyDefined';
 import pick from './utils/pick';
 import computeTree from './jsonUtils/computeTree';
-import createStringMeasurer from './utils/createStringMeasurer';
 import computeTextTree from './jsonUtils/computeTextTree';
 import {
   INHERITABLE_FONT_STYLES,
@@ -44,7 +43,7 @@ const reactTreeToFlexTree = (
 
     // Handle Text Children
     const textNodes = computeTextTree(node, context);
-    const layout = createStringMeasurer(textNodes)(0);
+    const layout = yogaNode ? yogaNode.getComputedLayout() : {};
 
     return Object.assign({}, SKETCH_TREE_OBJECT_STUB, {
       type: 'text',

--- a/src/flexToSketchJSON.js
+++ b/src/flexToSketchJSON.js
@@ -3,7 +3,7 @@ import renderers from './renderers';
 import type { TreeNode } from './types';
 
 const flexToSketchJSON = (node: TreeNode) => {
-  const { type, style, textStyle, layout, value, props, children } = node;
+  const { type, style, textStyle, layout, props, children } = node;
   const Renderer = renderers[type];
   if (Renderer == null) {
     // Give some insight as to why there might be issues
@@ -18,19 +18,12 @@ const flexToSketchJSON = (node: TreeNode) => {
   }
 
   const renderer = new Renderer();
-  const groupLayer = renderer.renderGroupLayer(
-    layout,
-    style,
-    textStyle,
-    props,
-    value
-  );
+  const groupLayer = renderer.renderGroupLayer(layout, style, textStyle, props);
   const backingLayers = renderer.renderBackingLayers(
     layout,
     style,
     textStyle,
-    props,
-    value
+    props
   );
 
   const sublayers = children.map(child => flexToSketchJSON(child));

--- a/src/jsonUtils/computeNode.js
+++ b/src/jsonUtils/computeNode.js
@@ -421,18 +421,9 @@ const computeNode = (node: TreeNode, context: Context) => {
     }
   }
 
-  // if Text node
-  if (
-    node &&
-    node.type === 'text' &&
-    node.children &&
-    (typeof node.children[0] === 'string' ||
-      typeof node.children[0] === 'number')
-  ) {
-    const content = String(node.children[0]);
+  if (typeof node === 'string' || typeof node === 'number') {
     const textStyle = context.getInheritedStyles();
-
-    yogaNode.setMeasureFunc(createStringMeasurer(node, content, textStyle));
+    yogaNode.setMeasureFunc(createStringMeasurer(node, node, textStyle));
   }
 
   return yogaNode;

--- a/src/jsonUtils/computeNode.js
+++ b/src/jsonUtils/computeNode.js
@@ -3,6 +3,9 @@ import * as yoga from 'yoga-layout';
 import type { TreeNode, ViewStyle } from '../types';
 import Context from '../utils/Context';
 import createStringMeasurer from '../utils/createStringMeasurer';
+import hasAnyDefined from '../utils/hasAnyDefined';
+import pick from '../utils/pick';
+import { INHERITABLE_FONT_STYLES } from '../utils/constants';
 
 // flatten all styles (including nested) into one object
 const getStyles = (node: TreeNode): ViewStyle | Object => {
@@ -421,9 +424,19 @@ const computeNode = (node: TreeNode, context: Context) => {
     }
   }
 
-  if (typeof node === 'string' || typeof node === 'number') {
+  if (typeof node === 'string') {
     const textStyle = context.getInheritedStyles();
-    yogaNode.setMeasureFunc(createStringMeasurer(node, node, textStyle));
+    yogaNode.setMeasureFunc(createStringMeasurer(node, textStyle));
+    return yogaNode;
+  }
+
+  if (
+    node.type === 'text' &&
+    node.props.style &&
+    hasAnyDefined(style, INHERITABLE_FONT_STYLES)
+  ) {
+    const inheritableStyles = pick(style, INHERITABLE_FONT_STYLES);
+    context.addInheritableStyles(inheritableStyles);
   }
 
   return yogaNode;

--- a/src/jsonUtils/computeNode.js
+++ b/src/jsonUtils/computeNode.js
@@ -7,6 +7,32 @@ import hasAnyDefined from '../utils/hasAnyDefined';
 import pick from '../utils/pick';
 import { INHERITABLE_FONT_STYLES } from '../utils/constants';
 
+const walkTextTree = (
+  textTree: TreeNode,
+  context: Context,
+  textNodes: Array<Object>
+) => {
+  if (typeof textTree === 'string') {
+    textNodes.push({
+      textStyles: context.getInheritedStyles(),
+      content: textTree,
+    });
+  }
+
+  if (textTree.children) {
+    for (let index = 0; index < textTree.children.length; index += 1) {
+      const textComponent = textTree.children[index];
+      walkTextTree(textComponent, context.forChildren(), textNodes);
+    }
+  }
+};
+
+const textTreeToNodes = (
+  root: TreeNode,
+  context: Context,
+  textNodes: Array<Object>
+) => walkTextTree(root, context, textNodes);
+
 // flatten all styles (including nested) into one object
 const getStyles = (node: TreeNode): ViewStyle | Object => {
   let style = node.props.style;
@@ -322,7 +348,22 @@ const computeNode = (
 
     // Handle Text Children
     if (node.children && node.children.length > 0) {
-      console.log(node.children);
+      const textNodes = [];
+      const childContext = context.forChildren();
+      // console.log(node.children);
+      for (let index = 0; index < node.children.length; index += 1) {
+        const textNode = node.children[index];
+        if (typeof textNode === 'string') {
+          textNodes.push({
+            content: textNode,
+            textStyles: childContext.getInheritedStyles(),
+          });
+        } else if (textNode.children && textNode.children.length > 0) {
+          console.log(textNode);
+          textTreeToNodes(textNode, childContext, textNodes);
+        }
+      }
+      console.log(textNodes);
     }
 
     return { node: yogaNode, stop: true };

--- a/src/jsonUtils/computeNode.js
+++ b/src/jsonUtils/computeNode.js
@@ -7,6 +7,7 @@ import hasAnyDefined from '../utils/hasAnyDefined';
 import pick from '../utils/pick';
 import computeTextTree from './computeTextTree';
 import { INHERITABLE_FONT_STYLES } from '../utils/constants';
+import { getSymbolMasterByName } from '../symbol';
 
 // flatten all styles (including nested) into one object
 const getStyles = (node: TreeNode): ViewStyle | Object => {
@@ -31,6 +32,14 @@ const computeNode = (
   const yogaNode = yoga.Node.create();
   const hasStyle = node.props && node.props.style;
   const style: ViewStyle | Object = hasStyle ? getStyles(node) : {};
+
+  // Setup default symbol instance dimensions
+  if (node.type === 'symbolinstance') {
+    const symbolProps = node.props;
+    const { frame } = getSymbolMasterByName(symbolProps.masterName);
+    yogaNode.setWidth(frame.width);
+    yogaNode.setHeight(frame.height);
+  }
 
   if (hasStyle) {
     // http://facebook.github.io/react-native/releases/0.48/docs/layout-props.html

--- a/src/jsonUtils/computeNode.js
+++ b/src/jsonUtils/computeNode.js
@@ -22,6 +22,8 @@ const isPercent = (value: number | string) => /%/.test(String(value));
 
 const isAuto = (value: number | string) => String(value) === 'auto';
 
+const isNullOrUndefined = (value: any) => value === null || value === undefined;
+
 const computeNode = (node: TreeNode, context: Context) => {
   const yogaNode = yoga.Node.create();
   const hasStyle = node.props && node.props.style;
@@ -31,7 +33,7 @@ const computeNode = (node: TreeNode, context: Context) => {
     // http://facebook.github.io/react-native/releases/0.48/docs/layout-props.html
 
     // Width
-    if (style.width) {
+    if (!isNullOrUndefined(style.width)) {
       if (isPercent(style.width)) {
         yogaNode.setWidthPercent(style.width);
       } else if (isAuto(style.width)) {
@@ -42,7 +44,7 @@ const computeNode = (node: TreeNode, context: Context) => {
     }
 
     // Height
-    if (style.height) {
+    if (!isNullOrUndefined(style.height)) {
       if (isPercent(style.height)) {
         yogaNode.setHeightPercent(style.height);
       } else if (isAuto(style.height)) {
@@ -53,7 +55,7 @@ const computeNode = (node: TreeNode, context: Context) => {
     }
 
     // Min-Height
-    if (style.minHeight) {
+    if (!isNullOrUndefined(style.minHeight)) {
       if (isPercent(style.minHeight)) {
         yogaNode.setMinHeightPercent(style.minHeight);
       } else {
@@ -62,7 +64,7 @@ const computeNode = (node: TreeNode, context: Context) => {
     }
 
     // Min-Width
-    if (style.minWidth) {
+    if (!isNullOrUndefined(style.minWidth)) {
       if (isPercent(style.minWidth)) {
         yogaNode.setMinWidthPercent(style.minWidth);
       } else {
@@ -71,7 +73,7 @@ const computeNode = (node: TreeNode, context: Context) => {
     }
 
     // Max-Height
-    if (style.maxHeight) {
+    if (!isNullOrUndefined(style.maxHeight)) {
       if (isPercent(style.maxHeight)) {
         yogaNode.setMaxHeightPercent(style.maxHeight);
       } else {
@@ -80,7 +82,7 @@ const computeNode = (node: TreeNode, context: Context) => {
     }
 
     // Min-Width
-    if (style.maxWidth) {
+    if (!isNullOrUndefined(style.maxWidth)) {
       if (isPercent(style.maxWidth)) {
         yogaNode.setMaxWidthPercent(style.maxWidth);
       } else {
@@ -89,7 +91,7 @@ const computeNode = (node: TreeNode, context: Context) => {
     }
 
     // Margin
-    if (style.marginTop) {
+    if (!isNullOrUndefined(style.marginTop)) {
       if (isPercent(style.marginTop)) {
         yogaNode.setMarginPercent(yoga.EDGE_TOP, style.marginTop);
       } else if (isAuto(style.marginTop)) {
@@ -98,7 +100,7 @@ const computeNode = (node: TreeNode, context: Context) => {
         yogaNode.setMargin(yoga.EDGE_TOP, style.marginTop);
       }
     }
-    if (style.marginBottom) {
+    if (!isNullOrUndefined(style.marginBottom)) {
       if (isPercent(style.marginBottom)) {
         yogaNode.setMarginPercent(yoga.EDGE_BOTTOM, style.marginBottom);
       } else if (isAuto(style.marginBottom)) {
@@ -107,7 +109,7 @@ const computeNode = (node: TreeNode, context: Context) => {
         yogaNode.setMargin(yoga.EDGE_BOTTOM, style.marginBottom);
       }
     }
-    if (style.marginLeft) {
+    if (!isNullOrUndefined(style.marginLeft)) {
       if (isPercent(style.marginLeft)) {
         yogaNode.setMarginPercent(yoga.EDGE_LEFT, style.marginLeft);
       } else if (isAuto(style.marginLeft)) {
@@ -116,7 +118,7 @@ const computeNode = (node: TreeNode, context: Context) => {
         yogaNode.setMargin(yoga.EDGE_LEFT, style.marginLeft);
       }
     }
-    if (style.marginRight) {
+    if (!isNullOrUndefined(style.marginRight)) {
       if (isPercent(style.marginRight)) {
         yogaNode.setMarginPercent(yoga.EDGE_RIGHT, style.marginRight);
       } else if (isAuto(style.marginRight)) {
@@ -125,7 +127,7 @@ const computeNode = (node: TreeNode, context: Context) => {
         yogaNode.setMargin(yoga.EDGE_RIGHT, style.marginRight);
       }
     }
-    if (style.marginVertical) {
+    if (!isNullOrUndefined(style.marginVertical)) {
       if (isPercent(style.marginVertical)) {
         yogaNode.setMarginPercent(yoga.EDGE_VERTICAL, style.marginVertical);
       } else if (isAuto(style.marginVertical)) {
@@ -134,7 +136,7 @@ const computeNode = (node: TreeNode, context: Context) => {
         yogaNode.setMargin(yoga.EDGE_VERTICAL, style.marginVertical);
       }
     }
-    if (style.marginHorizontal) {
+    if (!isNullOrUndefined(style.marginHorizontal)) {
       if (isPercent(style.marginHorizontal)) {
         yogaNode.setMarginPercent(yoga.EDGE_HORIZONTAL, style.marginHorizontal);
       } else if (isAuto(style.marginHorizontal)) {
@@ -143,7 +145,7 @@ const computeNode = (node: TreeNode, context: Context) => {
         yogaNode.setMargin(yoga.EDGE_HORIZONTAL, style.marginHorizontal);
       }
     }
-    if (style.margin) {
+    if (!isNullOrUndefined(style.margin)) {
       if (isPercent(style.margin)) {
         yogaNode.setMarginPercent(yoga.EDGE_ALL, style.margin);
       } else if (isAuto(style.margin)) {
@@ -154,42 +156,42 @@ const computeNode = (node: TreeNode, context: Context) => {
     }
 
     // Padding
-    if (style.paddingTop) {
+    if (!isNullOrUndefined(style.paddingTop)) {
       if (isPercent(style.paddingTop)) {
         yogaNode.setPaddingPercent(yoga.EDGE_TOP, style.paddingTop);
       } else {
         yogaNode.setPadding(yoga.EDGE_TOP, style.paddingTop);
       }
     }
-    if (style.paddingBottom) {
+    if (!isNullOrUndefined(style.paddingBottom)) {
       if (isPercent(style.paddingBottom)) {
         yogaNode.setPaddingPercent(yoga.EDGE_BOTTOM, style.paddingBottom);
       } else {
         yogaNode.setPadding(yoga.EDGE_BOTTOM, style.paddingBottom);
       }
     }
-    if (style.paddingLeft) {
+    if (!isNullOrUndefined(style.paddingLeft)) {
       if (isPercent(style.paddingLeft)) {
         yogaNode.setPaddingPercent(yoga.EDGE_LEFT, style.paddingLeft);
       } else {
         yogaNode.setPadding(yoga.EDGE_LEFT, style.paddingLeft);
       }
     }
-    if (style.paddingRight) {
+    if (!isNullOrUndefined(style.paddingRight)) {
       if (isPercent(style.paddingRight)) {
         yogaNode.setPaddingPercent(yoga.EDGE_RIGHT, style.paddingRight);
       } else {
         yogaNode.setPadding(yoga.EDGE_RIGHT, style.paddingRight);
       }
     }
-    if (style.paddingVertical) {
+    if (!isNullOrUndefined(style.paddingVertical)) {
       if (isPercent(style.paddingVertical)) {
         yogaNode.setPaddingPercent(yoga.EDGE_VERTICAL, style.paddingVertical);
       } else {
         yogaNode.setPadding(yoga.EDGE_VERTICAL, style.paddingVertical);
       }
     }
-    if (style.paddingHorizontal) {
+    if (!isNullOrUndefined(style.paddingHorizontal)) {
       if (isPercent(style.paddingHorizontal)) {
         yogaNode.setPaddingPercent(
           yoga.EDGE_HORIZONTAL,
@@ -199,7 +201,7 @@ const computeNode = (node: TreeNode, context: Context) => {
         yogaNode.setPadding(yoga.EDGE_HORIZONTAL, style.paddingHorizontal);
       }
     }
-    if (style.padding) {
+    if (!isNullOrUndefined(style.padding)) {
       if (isPercent(style.padding)) {
         yogaNode.setPaddingPercent(yoga.EDGE_ALL, style.padding);
       } else {
@@ -208,39 +210,39 @@ const computeNode = (node: TreeNode, context: Context) => {
     }
 
     // Border
-    if (style.borderTop) {
+    if (!isNullOrUndefined(style.borderTop)) {
       yogaNode.setBorder(yoga.EDGE_TOP, style.borderTop);
     }
-    if (style.borderBottom) {
+    if (!isNullOrUndefined(style.borderBottom)) {
       yogaNode.setBorder(yoga.EDGE_BOTTOM, style.borderBottom);
     }
-    if (style.borderLeft) {
+    if (!isNullOrUndefined(style.borderLeft)) {
       yogaNode.setBorder(yoga.EDGE_LEFT, style.borderLeft);
     }
-    if (style.borderRight) {
+    if (!isNullOrUndefined(style.borderRight)) {
       yogaNode.setBorder(yoga.EDGE_RIGHT, style.borderRight);
     }
-    if (style.borderVertical) {
+    if (!isNullOrUndefined(style.borderVertical)) {
       yogaNode.setBorder(yoga.EDGE_VERTICAL, style.borderVertical);
     }
-    if (style.borderHorizontal) {
+    if (!isNullOrUndefined(style.borderHorizontal)) {
       yogaNode.setBorder(yoga.EDGE_HORIZONTAL, style.borderHorizontal);
     }
-    if (style.border) {
+    if (!isNullOrUndefined(style.border)) {
       yogaNode.setBorder(yoga.EDGE_ALL, style.border);
     }
 
     // Flex
-    if (style.flex) {
+    if (!isNullOrUndefined(style.flex)) {
       yogaNode.setFlex(style.flex);
     }
-    if (style.flexGrow) {
+    if (!isNullOrUndefined(style.flexGrow)) {
       yogaNode.setFlexGrow(style.flexGrow);
     }
-    if (style.flexShrink) {
+    if (!isNullOrUndefined(style.flexShrink)) {
       yogaNode.setFlexShrink(style.flexShrink);
     }
-    if (style.flexBasis) {
+    if (!isNullOrUndefined(style.flexBasis)) {
       yogaNode.setFlexBasis(style.flexBasis);
     }
 
@@ -252,28 +254,28 @@ const computeNode = (node: TreeNode, context: Context) => {
       yogaNode.setPositionType(yoga.POSITION_TYPE_RELATIVE);
     }
 
-    if (style.top) {
+    if (!isNullOrUndefined(style.top)) {
       if (isPercent(style.top)) {
         yogaNode.setPositionPercent(yoga.EDGE_TOP, style.top);
       } else {
         yogaNode.setPosition(yoga.EDGE_TOP, style.top);
       }
     }
-    if (style.left) {
+    if (!isNullOrUndefined(style.left)) {
       if (isPercent(style.left)) {
         yogaNode.setPositionPercent(yoga.EDGE_LEFT, style.left);
       } else {
         yogaNode.setPosition(yoga.EDGE_LEFT, style.left);
       }
     }
-    if (style.right) {
+    if (!isNullOrUndefined(style.right)) {
       if (isPercent(style.right)) {
         yogaNode.setPositionPercent(yoga.EDGE_RIGHT, style.right);
       } else {
         yogaNode.setPosition(yoga.EDGE_RIGHT, style.right);
       }
     }
-    if (style.bottom) {
+    if (!isNullOrUndefined(style.bottom)) {
       if (isPercent(style.bottom)) {
         yogaNode.setPositionPercent(yoga.EDGE_BOTTOM, style.bottom);
       } else {
@@ -282,146 +284,138 @@ const computeNode = (node: TreeNode, context: Context) => {
     }
 
     // Display
-    const display = style.display;
-    if (display) {
-      if (display === 'flex') {
+    if (style.display) {
+      if (style.display === 'flex') {
         yogaNode.setDisplay(yoga.DISPLAY_FLEX);
       }
-      if (display === 'none') {
+      if (style.display === 'none') {
         yogaNode.setDisplay(yoga.DISPLAY_NONE);
       }
     }
 
     // Overflow
-    const overflow = style.overflow;
-    if (overflow) {
-      if (overflow === 'visible') {
+    if (style.overflow) {
+      if (style.overflow === 'visible') {
         yogaNode.setDisplay(yoga.OVERFLOW_VISIBLE);
       }
-      if (overflow === 'scroll') {
+      if (style.overflow === 'scroll') {
         yogaNode.setDisplay(yoga.OVERFLOW_SCROLL);
       }
-      if (overflow === 'hidden') {
+      if (style.overflow === 'hidden') {
         yogaNode.setDisplay(yoga.OVERFLOW_HIDDEN);
       }
     }
 
     // Flex direction
-    const flexDirection = style.flexDirection;
-    if (flexDirection) {
-      if (flexDirection === 'row') {
+    if (style.flexDirection) {
+      if (style.flexDirection === 'row') {
         yogaNode.setFlexDirection(yoga.FLEX_DIRECTION_ROW);
       }
-      if (flexDirection === 'column') {
+      if (style.flexDirection === 'column') {
         yogaNode.setFlexDirection(yoga.FLEX_DIRECTION_COLUMN);
       }
-      if (flexDirection === 'row-reverse') {
+      if (style.flexDirection === 'row-reverse') {
         yogaNode.setFlexDirection(yoga.FLEX_DIRECTION_ROW_REVERSE);
       }
-      if (flexDirection === 'column-reverse') {
+      if (style.flexDirection === 'column-reverse') {
         yogaNode.setFlexDirection(yoga.FLEX_DIRECTION_COLUMN_REVERSE);
       }
     }
 
     // Justify Content
-    const justifyContent = style.justifyContent;
-    if (justifyContent) {
-      if (justifyContent === 'flex-start') {
+    if (style.justifyContent) {
+      if (style.justifyContent === 'flex-start') {
         yogaNode.setJustifyContent(yoga.JUSTIFY_FLEX_START);
       }
-      if (justifyContent === 'flex-end') {
+      if (style.justifyContent === 'flex-end') {
         yogaNode.setJustifyContent(yoga.JUSTIFY_FLEX_END);
       }
-      if (justifyContent === 'center') {
+      if (style.justifyContent === 'center') {
         yogaNode.setJustifyContent(yoga.JUSTIFY_CENTER);
       }
-      if (justifyContent === 'space-between') {
+      if (style.justifyContent === 'space-between') {
         yogaNode.setJustifyContent(yoga.JUSTIFY_SPACE_BETWEEN);
       }
-      if (justifyContent === 'space-around') {
+      if (style.justifyContent === 'space-around') {
         yogaNode.setJustifyContent(yoga.JUSTIFY_SPACE_AROUND);
       }
     }
 
     // Align Content
-    const alignContent = style.alignContent;
-    if (alignContent) {
-      if (alignContent === 'flex-start') {
+    if (style.alignContent) {
+      if (style.alignContent === 'flex-start') {
         yogaNode.setAlignContent(yoga.ALIGN_FLEX_START);
       }
-      if (alignContent === 'flex-end') {
+      if (style.alignContent === 'flex-end') {
         yogaNode.setAlignContent(yoga.ALIGN_FLEX_END);
       }
-      if (alignContent === 'center') {
+      if (style.alignContent === 'center') {
         yogaNode.setAlignContent(yoga.ALIGN_CENTER);
       }
-      if (alignContent === 'stretch') {
+      if (style.alignContent === 'stretch') {
         yogaNode.setAlignContent(yoga.ALIGN_STRETCH);
       }
-      if (alignContent === 'baseline') {
+      if (style.alignContent === 'baseline') {
         yogaNode.setAlignContent(yoga.ALIGN_BASELINE);
       }
-      if (alignContent === 'space-between') {
+      if (style.alignContent === 'space-between') {
         yogaNode.setAlignContent(yoga.ALIGN_SPACE_BETWEEN);
       }
-      if (alignContent === 'space-around') {
+      if (style.alignContent === 'space-around') {
         yogaNode.setAlignContent(yoga.ALIGN_SPACE_AROUND);
       }
-      if (alignContent === 'auto') {
+      if (style.alignContent === 'auto') {
         yogaNode.setAlignContent(yoga.ALIGN_AUTO);
       }
     }
 
     // Align Items
-    const alignItems = style.alignItems;
-    if (alignItems) {
-      if (alignItems === 'flex-start') {
+    if (style.alignItems) {
+      if (style.alignItems === 'flex-start') {
         yogaNode.setAlignItems(yoga.ALIGN_FLEX_START);
       }
-      if (alignItems === 'flex-end') {
+      if (style.alignItems === 'flex-end') {
         yogaNode.setAlignItems(yoga.ALIGN_FLEX_END);
       }
-      if (alignItems === 'center') {
+      if (style.alignItems === 'center') {
         yogaNode.setAlignItems(yoga.ALIGN_CENTER);
       }
-      if (alignItems === 'stretch') {
+      if (style.alignItems === 'stretch') {
         yogaNode.setAlignItems(yoga.ALIGN_STRETCH);
       }
-      if (alignItems === 'baseline') {
+      if (style.alignItems === 'baseline') {
         yogaNode.setAlignItems(yoga.ALIGN_BASELINE);
       }
     }
 
     // Align Self
-    const alignSelf = style.alignSelf;
-    if (alignSelf) {
-      if (alignSelf === 'flex-start') {
+    if (style.alignSelf) {
+      if (style.alignSelf === 'flex-start') {
         yogaNode.setAlignSelf(yoga.ALIGN_FLEX_END);
       }
-      if (alignSelf === 'flex-end') {
+      if (style.alignSelf === 'flex-end') {
         yogaNode.setAlignSelf(yoga.ALIGN_FLEX_END);
       }
-      if (alignSelf === 'center') {
+      if (style.alignSelf === 'center') {
         yogaNode.setAlignSelf(yoga.ALIGN_CENTER);
       }
-      if (alignSelf === 'stretch') {
+      if (style.alignSelf === 'stretch') {
         yogaNode.setAlignSelf(yoga.ALIGN_STRETCH);
       }
-      if (alignSelf === 'baseline') {
+      if (style.alignSelf === 'baseline') {
         yogaNode.setAlignSelf(yoga.ALIGN_BASELINE);
       }
     }
 
     // Flex Wrap
-    const flexWrap = style.flexWrap;
-    if (flexWrap) {
-      if (flexWrap === 'nowrap') {
+    if (style.flexWrap) {
+      if (style.flexWrap === 'nowrap') {
         yogaNode.setFlexWrap(yoga.WRAP_NO_WRAP);
       }
-      if (flexWrap === 'wrap') {
+      if (style.flexWrap === 'wrap') {
         yogaNode.setFlexWrap(yoga.WRAP_WRAP);
       }
-      if (flexWrap === 'wrap-reverse') {
+      if (style.flexWrap === 'wrap-reverse') {
         yogaNode.setFlexWrap(yoga.WRAP_WRAP_REVERSE);
       }
     }

--- a/src/jsonUtils/computeNode.js
+++ b/src/jsonUtils/computeNode.js
@@ -431,18 +431,8 @@ const computeNode = (node: TreeNode, context: Context) => {
   ) {
     const content = String(node.children[0]);
     const textStyle = context.getInheritedStyles();
-    const measure = createStringMeasurer(content, textStyle)();
 
-    if (!style.height) {
-      yogaNode.setHeight(measure.height);
-    }
-
-    // Use hardcoded width if present
-    if (style.width || typeof style.width === 'number') {
-      return yogaNode;
-    }
-
-    yogaNode.setWidth(measure.width);
+    yogaNode.setMeasureFunc(createStringMeasurer(content, textStyle));
   }
 
   return yogaNode;

--- a/src/jsonUtils/computeNode.js
+++ b/src/jsonUtils/computeNode.js
@@ -5,33 +5,8 @@ import Context from '../utils/Context';
 import createStringMeasurer from '../utils/createStringMeasurer';
 import hasAnyDefined from '../utils/hasAnyDefined';
 import pick from '../utils/pick';
+import computeTextTree from './computeTextTree';
 import { INHERITABLE_FONT_STYLES } from '../utils/constants';
-
-const walkTextTree = (
-  textTree: TreeNode,
-  context: Context,
-  textNodes: Array<Object>
-) => {
-  if (typeof textTree === 'string') {
-    textNodes.push({
-      textStyles: context.getInheritedStyles(),
-      content: textTree,
-    });
-  }
-
-  if (textTree.children) {
-    for (let index = 0; index < textTree.children.length; index += 1) {
-      const textComponent = textTree.children[index];
-      walkTextTree(textComponent, context.forChildren(), textNodes);
-    }
-  }
-};
-
-const textTreeToNodes = (
-  root: TreeNode,
-  context: Context,
-  textNodes: Array<Object>
-) => walkTextTree(root, context, textNodes);
 
 // flatten all styles (including nested) into one object
 const getStyles = (node: TreeNode): ViewStyle | Object => {
@@ -332,12 +307,6 @@ const computeNode = (
     }
   }
 
-  // if (typeof node === 'string') {
-  //   const textStyle = context.getInheritedStyles();
-  //   yogaNode.setMeasureFunc(createStringMeasurer(node, textStyle));
-  //   return yogaNode;
-  // }
-
   if (node.type === 'text') {
     // If current node is a Text node, add text styles to Context to pass down to
     // child nodes.
@@ -347,24 +316,8 @@ const computeNode = (
     }
 
     // Handle Text Children
-    if (node.children && node.children.length > 0) {
-      const textNodes = [];
-      const childContext = context.forChildren();
-      // console.log(node.children);
-      for (let index = 0; index < node.children.length; index += 1) {
-        const textNode = node.children[index];
-        if (typeof textNode === 'string') {
-          textNodes.push({
-            content: textNode,
-            textStyles: childContext.getInheritedStyles(),
-          });
-        } else if (textNode.children && textNode.children.length > 0) {
-          console.log(textNode);
-          textTreeToNodes(textNode, childContext, textNodes);
-        }
-      }
-      console.log(textNodes);
-    }
+    const textNodes = computeTextTree(node, context);
+    yogaNode.setMeasureFunc(createStringMeasurer(textNodes));
 
     return { node: yogaNode, stop: true };
   }

--- a/src/jsonUtils/computeNode.js
+++ b/src/jsonUtils/computeNode.js
@@ -1,0 +1,241 @@
+// @flow
+import * as yoga from 'yoga-layout';
+import type { TreeNode, ViewStyle } from '../types';
+import Context from '../utils/Context';
+import createStringMeasurer from '../utils/createStringMeasurer';
+
+// flatten all styles (including nested) into one object
+const getStyles = (node: TreeNode): ViewStyle | Object => {
+  let style = node.props.style;
+
+  if (Array.isArray(style)) {
+    const flattened = Array.prototype.concat.apply([], style);
+    const themeFlattened = Array.prototype.concat.apply([], flattened);
+    const objectsOnly = themeFlattened.filter(f => f);
+    style = Object.assign({}, ...objectsOnly);
+  }
+
+  return style;
+};
+
+const computeNode = (node: TreeNode, context: Context) => {
+  const yogaNode = yoga.Node.create();
+  const hasStyle = node.props && node.props.style;
+  const style: ViewStyle | Object = hasStyle ? getStyles(node) : {};
+
+  if (hasStyle) {
+    // http://facebook.github.io/react-native/releases/0.48/docs/layout-props.html
+
+    // Height & Width
+    if (style.width) {
+      yogaNode.setWidth(style.width);
+    }
+    if (style.height) {
+      yogaNode.setHeight(style.height);
+    }
+
+    if (style.minHeight) {
+      yogaNode.setMinHeight(style.minHeight);
+    }
+    if (style.minWidth) {
+      yogaNode.setMinWidth(style.minWidth);
+    }
+
+    if (style.maxHeight) {
+      yogaNode.setMaxHeight(style.maxHeight);
+    }
+    if (style.maxWidth) {
+      yogaNode.setMaxWidth(style.maxWidth);
+    }
+
+    // Margin
+    if (style.marginTop) {
+      yogaNode.setMargin(yoga.EDGE_TOP, style.marginTop);
+    }
+    if (style.marginBottom) {
+      yogaNode.setMargin(yoga.EDGE_BOTTOM, style.marginBottom);
+    }
+    if (style.marginLeft) {
+      yogaNode.setMargin(yoga.EDGE_LEFT, style.marginLeft);
+    }
+    if (style.marginRight) {
+      yogaNode.setMargin(yoga.EDGE_RIGHT, style.marginRight);
+    }
+    if (style.marginVertical) {
+      yogaNode.setMargin(yoga.EDGE_VERTICAL, style.marginVertical);
+    }
+    if (style.marginHorizontal) {
+      yogaNode.setMargin(yoga.EDGE_HORIZONTAL, style.marginHorizontal);
+    }
+
+    // Padding
+    if (style.paddingTop) {
+      yogaNode.setPadding(yoga.EDGE_TOP, style.paddingTop);
+    }
+    if (style.paddingBottom) {
+      yogaNode.setPadding(yoga.EDGE_BOTTOM, style.paddingBottom);
+    }
+    if (style.paddingLeft) {
+      yogaNode.setPadding(yoga.EDGE_LEFT, style.paddingLeft);
+    }
+    if (style.paddingRight) {
+      yogaNode.setPadding(yoga.EDGE_RIGHT, style.paddingRight);
+    }
+    if (style.paddingVertical) {
+      yogaNode.setPadding(yoga.EDGE_VERTICAL, style.paddingVertical);
+    }
+    if (style.paddingHorizontal) {
+      yogaNode.setPadding(yoga.EDGE_HORIZONTAL, style.paddingHorizontal);
+    }
+
+    // Flex
+    if (style.flex) {
+      yogaNode.setFlex(style.flex);
+    }
+    if (style.flexGrow) {
+      yogaNode.setFlexGrow(style.flexGrow);
+    }
+    if (style.flexShrink) {
+      yogaNode.setFlexShrink(style.flexShrink);
+    }
+    if (style.flexBasis) {
+      yogaNode.setFlexBasis(style.flexBasis);
+    }
+
+    // Position
+    if (style.position === 'absolute') {
+      yogaNode.setPositionType(yoga.POSITION_TYPE_ABSOLUTE);
+    }
+    if (style.top) {
+      yogaNode.setPosition(yoga.EDGE_TOP, style.top);
+    }
+    if (style.left) {
+      yogaNode.setPosition(yoga.EDGE_LEFT, style.left);
+    }
+    if (style.right) {
+      yogaNode.setPosition(yoga.EDGE_RIGHT, style.right);
+    }
+    if (style.bottom) {
+      yogaNode.setPosition(yoga.EDGE_BOTTOM, style.bottom);
+    }
+
+    // Flex direction
+    const flexDirection = style.flexDirection;
+    if (flexDirection) {
+      if (flexDirection === 'row') {
+        yogaNode.setFlexDirection(yoga.FLEX_DIRECTION_ROW);
+      }
+      if (flexDirection === 'column') {
+        yogaNode.setFlexDirection(yoga.FLEX_DIRECTION_COLUMN);
+      }
+      if (flexDirection === 'row-reverse') {
+        yogaNode.setFlexDirection(yoga.FLEX_DIRECTION_ROW_REVERSE);
+      }
+      if (flexDirection === 'column-reverse') {
+        yogaNode.setFlexDirection(yoga.FLEX_DIRECTION_COLUMN_REVERSE);
+      }
+    }
+
+    // Justify Content
+    const justifyContent = style.justifyContent;
+    if (justifyContent) {
+      if (justifyContent === 'flex-start') {
+        yogaNode.setJustifyContent(yoga.JUSTIFY_FLEX_START);
+      }
+      if (justifyContent === 'flex-end') {
+        yogaNode.setJustifyContent(yoga.JUSTIFY_FLEX_END);
+      }
+      if (justifyContent === 'center') {
+        yogaNode.setJustifyContent(yoga.JUSTIFY_CENTER);
+      }
+      if (justifyContent === 'space-between') {
+        yogaNode.setJustifyContent(yoga.JUSTIFY_SPACE_BETWEEN);
+      }
+      if (justifyContent === 'space-around') {
+        yogaNode.setJustifyContent(yoga.JUSTIFY_SPACE_AROUND);
+      }
+    }
+
+    // Align Items
+    const alignItems = style.alignItems;
+    if (alignItems) {
+      if (alignItems === 'flex-start') {
+        yogaNode.setAlignItems(yoga.ALIGN_FLEX_END);
+      }
+      if (alignItems === 'flex-end') {
+        yogaNode.setAlignItems(yoga.ALIGN_FLEX_END);
+      }
+      if (alignItems === 'center') {
+        yogaNode.setAlignItems(yoga.ALIGN_CENTER);
+      }
+      if (alignItems === 'stretch') {
+        yogaNode.setAlignItems(yoga.ALIGN_STRETCH);
+      }
+      if (alignItems === 'baseline') {
+        yogaNode.setAlignItems(yoga.ALIGN_BASELINE);
+      }
+    }
+
+    // Align Self
+    const alignSelf = style.alignSelf;
+    if (alignSelf) {
+      if (alignSelf === 'flex-start') {
+        yogaNode.setAlignSelf(yoga.ALIGN_FLEX_END);
+      }
+      if (alignSelf === 'flex-end') {
+        yogaNode.setAlignSelf(yoga.ALIGN_FLEX_END);
+      }
+      if (alignSelf === 'center') {
+        yogaNode.setAlignSelf(yoga.ALIGN_CENTER);
+      }
+      if (alignSelf === 'stretch') {
+        yogaNode.setAlignSelf(yoga.ALIGN_STRETCH);
+      }
+      if (alignSelf === 'baseline') {
+        yogaNode.setAlignSelf(yoga.ALIGN_BASELINE);
+      }
+    }
+
+    // Flex Wrap
+    const flexWrap = style.flexWrap;
+    if (flexWrap) {
+      if (flexWrap === 'nowrap') {
+        yogaNode.setFlexWrap(yoga.WRAP_NO_WRAP);
+      }
+      if (flexWrap === 'wrap') {
+        yogaNode.setFlexWrap(yoga.WRAP_WRAP);
+      }
+      if (flexWrap === 'wrap-reverse') {
+        yogaNode.setFlexWrap(yoga.WRAP_WRAP_REVERSE);
+      }
+    }
+  }
+
+  // if Text node
+  if (
+    node &&
+    node.type === 'text' &&
+    node.children &&
+    (typeof node.children[0] === 'string' ||
+      typeof node.children[0] === 'number')
+  ) {
+    const content = String(node.children[0]);
+    const textStyle = context.getInheritedStyles();
+    const measure = createStringMeasurer(content, textStyle)();
+
+    if (!style.height) {
+      yogaNode.setHeight(measure.height);
+    }
+
+    // Use hardcoded width if present
+    if (style.width || typeof style.width === 'number') {
+      return yogaNode;
+    }
+
+    yogaNode.setWidth(measure.width);
+  }
+
+  return yogaNode;
+};
+
+export default computeNode;

--- a/src/jsonUtils/computeNode.js
+++ b/src/jsonUtils/computeNode.js
@@ -18,6 +18,10 @@ const getStyles = (node: TreeNode): ViewStyle | Object => {
   return style;
 };
 
+const isPercent = (value: number | string) => /%/.test(String(value));
+
+const isAuto = (value: number | string) => String(value) === 'auto';
+
 const computeNode = (node: TreeNode, context: Context) => {
   const yogaNode = yoga.Node.create();
   const hasStyle = node.props && node.props.style;
@@ -28,64 +32,194 @@ const computeNode = (node: TreeNode, context: Context) => {
 
     // Height & Width
     if (style.width) {
-      yogaNode.setWidth(style.width);
+      if (isPercent(style.width)) {
+        yogaNode.setWidthPercent(style.width);
+      } else if (isAuto(style.width)) {
+        yogaNode.setWidthAuto();
+      } else {
+        yogaNode.setWidth(style.width);
+      }
     }
     if (style.height) {
-      yogaNode.setHeight(style.height);
+      if (isPercent(style.height)) {
+        yogaNode.setHeightPercent(style.height);
+      } else if (isAuto(style.height)) {
+        yogaNode.setHeightAuto();
+      } else {
+        yogaNode.setHeight(style.height);
+      }
     }
 
     if (style.minHeight) {
-      yogaNode.setMinHeight(style.minHeight);
+      if (isPercent(style.minHeight)) {
+        yogaNode.setMinHeightPercent(style.minHeight);
+      } else {
+        yogaNode.setMinHeight(style.minHeight);
+      }
     }
     if (style.minWidth) {
-      yogaNode.setMinWidth(style.minWidth);
+      if (isPercent(style.minWidth)) {
+        yogaNode.setMinWidthPercent(style.minWidth);
+      } else {
+        yogaNode.setMinWidth(style.minWidth);
+      }
     }
 
     if (style.maxHeight) {
-      yogaNode.setMaxHeight(style.maxHeight);
+      if (isPercent(style.maxHeight)) {
+        yogaNode.setMaxHeightPercent(style.maxHeight);
+      } else {
+        yogaNode.setMaxHeight(style.maxHeight);
+      }
     }
     if (style.maxWidth) {
-      yogaNode.setMaxWidth(style.maxWidth);
+      if (isPercent(style.maxWidth)) {
+        yogaNode.setMaxWidthPercent(style.maxWidth);
+      } else {
+        yogaNode.setMaxWidth(style.maxWidth);
+      }
     }
 
     // Margin
     if (style.marginTop) {
-      yogaNode.setMargin(yoga.EDGE_TOP, style.marginTop);
+      if (isPercent(style.marginTop)) {
+        yogaNode.setMarginPercent(yoga.EDGE_TOP, style.marginTop);
+      } else if (isAuto(style.marginTop)) {
+        yogaNode.setMarginAuto(yoga.EDGE_TOP);
+      } else {
+        yogaNode.setMargin(yoga.EDGE_TOP, style.marginTop);
+      }
     }
     if (style.marginBottom) {
-      yogaNode.setMargin(yoga.EDGE_BOTTOM, style.marginBottom);
+      if (isPercent(style.marginBottom)) {
+        yogaNode.setMarginPercent(yoga.EDGE_BOTTOM, style.marginBottom);
+      } else if (isAuto(style.marginBottom)) {
+        yogaNode.setMarginAuto(yoga.EDGE_BOTTOM);
+      } else {
+        yogaNode.setMargin(yoga.EDGE_BOTTOM, style.marginBottom);
+      }
     }
     if (style.marginLeft) {
-      yogaNode.setMargin(yoga.EDGE_LEFT, style.marginLeft);
+      if (isPercent(style.marginLeft)) {
+        yogaNode.setMarginPercent(yoga.EDGE_LEFT, style.marginLeft);
+      } else if (isAuto(style.marginLeft)) {
+        yogaNode.setMarginAuto(yoga.EDGE_LEFT);
+      } else {
+        yogaNode.setMargin(yoga.EDGE_LEFT, style.marginLeft);
+      }
     }
     if (style.marginRight) {
-      yogaNode.setMargin(yoga.EDGE_RIGHT, style.marginRight);
+      if (isPercent(style.marginRight)) {
+        yogaNode.setMarginPercent(yoga.EDGE_RIGHT, style.marginRight);
+      } else if (isAuto(style.marginRight)) {
+        yogaNode.setMarginAuto(yoga.EDGE_RIGHT);
+      } else {
+        yogaNode.setMargin(yoga.EDGE_RIGHT, style.marginRight);
+      }
     }
     if (style.marginVertical) {
-      yogaNode.setMargin(yoga.EDGE_VERTICAL, style.marginVertical);
+      if (isPercent(style.marginVertical)) {
+        yogaNode.setMarginPercent(yoga.EDGE_VERTICAL, style.marginVertical);
+      } else if (isAuto(style.marginVertical)) {
+        yogaNode.setMarginAuto(yoga.EDGE_VERTICAL);
+      } else {
+        yogaNode.setMargin(yoga.EDGE_VERTICAL, style.marginVertical);
+      }
     }
     if (style.marginHorizontal) {
-      yogaNode.setMargin(yoga.EDGE_HORIZONTAL, style.marginHorizontal);
+      if (isPercent(style.marginHorizontal)) {
+        yogaNode.setMarginPercent(yoga.EDGE_HORIZONTAL, style.marginHorizontal);
+      } else if (isAuto(style.marginHorizontal)) {
+        yogaNode.setMarginAuto(yoga.EDGE_HORIZONTAL);
+      } else {
+        yogaNode.setMargin(yoga.EDGE_HORIZONTAL, style.marginHorizontal);
+      }
+    }
+    if (style.margin) {
+      if (isPercent(style.margin)) {
+        yogaNode.setMarginPercent(yoga.EDGE_ALL, style.margin);
+      } else if (isAuto(style.margin)) {
+        yogaNode.setMarginAuto(yoga.EDGE_ALL);
+      } else {
+        yogaNode.setMargin(yoga.EDGE_ALL, style.margin);
+      }
     }
 
     // Padding
     if (style.paddingTop) {
-      yogaNode.setPadding(yoga.EDGE_TOP, style.paddingTop);
+      if (isPercent(style.paddingTop)) {
+        yogaNode.setPaddingPercent(yoga.EDGE_TOP, style.paddingTop);
+      } else {
+        yogaNode.setPadding(yoga.EDGE_TOP, style.paddingTop);
+      }
     }
     if (style.paddingBottom) {
-      yogaNode.setPadding(yoga.EDGE_BOTTOM, style.paddingBottom);
+      if (isPercent(style.paddingBottom)) {
+        yogaNode.setPaddingPercent(yoga.EDGE_BOTTOM, style.paddingBottom);
+      } else {
+        yogaNode.setPadding(yoga.EDGE_BOTTOM, style.paddingBottom);
+      }
     }
     if (style.paddingLeft) {
-      yogaNode.setPadding(yoga.EDGE_LEFT, style.paddingLeft);
+      if (isPercent(style.paddingLeft)) {
+        yogaNode.setPaddingPercent(yoga.EDGE_LEFT, style.paddingLeft);
+      } else {
+        yogaNode.setPadding(yoga.EDGE_LEFT, style.paddingLeft);
+      }
     }
     if (style.paddingRight) {
-      yogaNode.setPadding(yoga.EDGE_RIGHT, style.paddingRight);
+      if (isPercent(style.paddingRight)) {
+        yogaNode.setPaddingPercent(yoga.EDGE_RIGHT, style.paddingRight);
+      } else {
+        yogaNode.setPadding(yoga.EDGE_RIGHT, style.paddingRight);
+      }
     }
     if (style.paddingVertical) {
-      yogaNode.setPadding(yoga.EDGE_VERTICAL, style.paddingVertical);
+      if (isPercent(style.paddingVertical)) {
+        yogaNode.setPaddingPercent(yoga.EDGE_VERTICAL, style.paddingVertical);
+      } else {
+        yogaNode.setPadding(yoga.EDGE_VERTICAL, style.paddingVertical);
+      }
     }
     if (style.paddingHorizontal) {
-      yogaNode.setPadding(yoga.EDGE_HORIZONTAL, style.paddingHorizontal);
+      if (isPercent(style.paddingHorizontal)) {
+        yogaNode.setPaddingPercent(
+          yoga.EDGE_HORIZONTAL,
+          style.paddingHorizontal
+        );
+      } else {
+        yogaNode.setPadding(yoga.EDGE_HORIZONTAL, style.paddingHorizontal);
+      }
+    }
+    if (style.padding) {
+      if (isPercent(style.padding)) {
+        yogaNode.setPaddingPercent(yoga.EDGE_ALL, style.padding);
+      } else {
+        yogaNode.setPadding(yoga.EDGE_ALL, style.padding);
+      }
+    }
+
+    // Border
+    if (style.borderTop) {
+      yogaNode.setBorder(yoga.EDGE_TOP, style.borderTop);
+    }
+    if (style.borderBottom) {
+      yogaNode.setBorder(yoga.EDGE_BOTTOM, style.borderBottom);
+    }
+    if (style.borderLeft) {
+      yogaNode.setBorder(yoga.EDGE_LEFT, style.borderLeft);
+    }
+    if (style.borderRight) {
+      yogaNode.setBorder(yoga.EDGE_RIGHT, style.borderRight);
+    }
+    if (style.borderVertical) {
+      yogaNode.setBorder(yoga.EDGE_VERTICAL, style.borderVertical);
+    }
+    if (style.borderHorizontal) {
+      yogaNode.setBorder(yoga.EDGE_HORIZONTAL, style.borderHorizontal);
+    }
+    if (style.border) {
+      yogaNode.setBorder(yoga.EDGE_ALL, style.border);
     }
 
     // Flex
@@ -106,17 +240,62 @@ const computeNode = (node: TreeNode, context: Context) => {
     if (style.position === 'absolute') {
       yogaNode.setPositionType(yoga.POSITION_TYPE_ABSOLUTE);
     }
+    if (style.position === 'relative') {
+      yogaNode.setPositionType(yoga.POSITION_TYPE_RELATIVE);
+    }
+
     if (style.top) {
-      yogaNode.setPosition(yoga.EDGE_TOP, style.top);
+      if (isPercent(style.top)) {
+        yogaNode.setPositionPercent(yoga.EDGE_TOP, style.top);
+      } else {
+        yogaNode.setPosition(yoga.EDGE_TOP, style.top);
+      }
     }
     if (style.left) {
-      yogaNode.setPosition(yoga.EDGE_LEFT, style.left);
+      if (isPercent(style.left)) {
+        yogaNode.setPositionPercent(yoga.EDGE_LEFT, style.left);
+      } else {
+        yogaNode.setPosition(yoga.EDGE_LEFT, style.left);
+      }
     }
     if (style.right) {
-      yogaNode.setPosition(yoga.EDGE_RIGHT, style.right);
+      if (isPercent(style.right)) {
+        yogaNode.setPositionPercent(yoga.EDGE_RIGHT, style.right);
+      } else {
+        yogaNode.setPosition(yoga.EDGE_RIGHT, style.right);
+      }
     }
     if (style.bottom) {
-      yogaNode.setPosition(yoga.EDGE_BOTTOM, style.bottom);
+      if (isPercent(style.bottom)) {
+        yogaNode.setPositionPercent(yoga.EDGE_BOTTOM, style.bottom);
+      } else {
+        yogaNode.setPosition(yoga.EDGE_BOTTOM, style.bottom);
+      }
+    }
+
+    // Display
+    const display = style.display;
+    if (display) {
+      if (display === 'flex') {
+        yogaNode.setDisplay(yoga.DISPLAY_FLEX);
+      }
+      if (display === 'none') {
+        yogaNode.setDisplay(yoga.DISPLAY_NONE);
+      }
+    }
+
+    // Overflow
+    const overflow = style.overflow;
+    if (overflow) {
+      if (overflow === 'visible') {
+        yogaNode.setDisplay(yoga.OVERFLOW_VISIBLE);
+      }
+      if (overflow === 'scroll') {
+        yogaNode.setDisplay(yoga.OVERFLOW_SCROLL);
+      }
+      if (overflow === 'hidden') {
+        yogaNode.setDisplay(yoga.OVERFLOW_HIDDEN);
+      }
     }
 
     // Flex direction
@@ -156,11 +335,40 @@ const computeNode = (node: TreeNode, context: Context) => {
       }
     }
 
+    // Align Content
+    const alignContent = style.alignContent;
+    if (alignContent) {
+      if (alignContent === 'flex-start') {
+        yogaNode.setAlignContent(yoga.ALIGN_FLEX_START);
+      }
+      if (alignContent === 'flex-end') {
+        yogaNode.setAlignContent(yoga.ALIGN_FLEX_END);
+      }
+      if (alignContent === 'center') {
+        yogaNode.setAlignContent(yoga.ALIGN_CENTER);
+      }
+      if (alignContent === 'stretch') {
+        yogaNode.setAlignContent(yoga.ALIGN_STRETCH);
+      }
+      if (alignContent === 'baseline') {
+        yogaNode.setAlignContent(yoga.ALIGN_BASELINE);
+      }
+      if (alignContent === 'space-between') {
+        yogaNode.setAlignContent(yoga.ALIGN_SPACE_BETWEEN);
+      }
+      if (alignContent === 'space-around') {
+        yogaNode.setAlignContent(yoga.ALIGN_SPACE_AROUND);
+      }
+      if (alignContent === 'auto') {
+        yogaNode.setAlignContent(yoga.ALIGN_AUTO);
+      }
+    }
+
     // Align Items
     const alignItems = style.alignItems;
     if (alignItems) {
       if (alignItems === 'flex-start') {
-        yogaNode.setAlignItems(yoga.ALIGN_FLEX_END);
+        yogaNode.setAlignItems(yoga.ALIGN_FLEX_START);
       }
       if (alignItems === 'flex-end') {
         yogaNode.setAlignItems(yoga.ALIGN_FLEX_END);

--- a/src/jsonUtils/computeNode.js
+++ b/src/jsonUtils/computeNode.js
@@ -432,7 +432,7 @@ const computeNode = (node: TreeNode, context: Context) => {
     const content = String(node.children[0]);
     const textStyle = context.getInheritedStyles();
 
-    yogaNode.setMeasureFunc(createStringMeasurer(content, textStyle));
+    yogaNode.setMeasureFunc(createStringMeasurer(node, content, textStyle));
   }
 
   return yogaNode;

--- a/src/jsonUtils/computeNode.js
+++ b/src/jsonUtils/computeNode.js
@@ -21,10 +21,6 @@ const getStyles = (node: TreeNode): ViewStyle | Object => {
   return style;
 };
 
-const isPercent = (value: number | string) => /%/.test(String(value));
-
-const isAuto = (value: number | string) => String(value) === 'auto';
-
 const isNullOrUndefined = (value: any) => value === null || value === undefined;
 
 const computeNode = (node: TreeNode, context: Context) => {
@@ -37,179 +33,78 @@ const computeNode = (node: TreeNode, context: Context) => {
 
     // Width
     if (!isNullOrUndefined(style.width)) {
-      if (isPercent(style.width)) {
-        yogaNode.setWidthPercent(style.width);
-      } else if (isAuto(style.width)) {
-        yogaNode.setWidthAuto();
-      } else {
-        yogaNode.setWidth(style.width);
-      }
+      yogaNode.setWidth(style.width);
     }
 
     // Height
     if (!isNullOrUndefined(style.height)) {
-      if (isPercent(style.height)) {
-        yogaNode.setHeightPercent(style.height);
-      } else if (isAuto(style.height)) {
-        yogaNode.setHeightAuto();
-      } else {
-        yogaNode.setHeight(style.height);
-      }
+      yogaNode.setHeight(style.height);
     }
 
     // Min-Height
     if (!isNullOrUndefined(style.minHeight)) {
-      if (isPercent(style.minHeight)) {
-        yogaNode.setMinHeightPercent(style.minHeight);
-      } else {
-        yogaNode.setMinHeight(style.minHeight);
-      }
+      yogaNode.setMinHeight(style.minHeight);
     }
 
     // Min-Width
     if (!isNullOrUndefined(style.minWidth)) {
-      if (isPercent(style.minWidth)) {
-        yogaNode.setMinWidthPercent(style.minWidth);
-      } else {
-        yogaNode.setMinWidth(style.minWidth);
-      }
+      yogaNode.setMinWidth(style.minWidth);
     }
 
     // Max-Height
     if (!isNullOrUndefined(style.maxHeight)) {
-      if (isPercent(style.maxHeight)) {
-        yogaNode.setMaxHeightPercent(style.maxHeight);
-      } else {
-        yogaNode.setMaxHeight(style.maxHeight);
-      }
+      yogaNode.setMaxHeight(style.maxHeight);
     }
 
     // Min-Width
     if (!isNullOrUndefined(style.maxWidth)) {
-      if (isPercent(style.maxWidth)) {
-        yogaNode.setMaxWidthPercent(style.maxWidth);
-      } else {
-        yogaNode.setMaxWidth(style.maxWidth);
-      }
+      yogaNode.setMaxWidth(style.maxWidth);
     }
 
     // Margin
     if (!isNullOrUndefined(style.marginTop)) {
-      if (isPercent(style.marginTop)) {
-        yogaNode.setMarginPercent(yoga.EDGE_TOP, style.marginTop);
-      } else if (isAuto(style.marginTop)) {
-        yogaNode.setMarginAuto(yoga.EDGE_TOP);
-      } else {
-        yogaNode.setMargin(yoga.EDGE_TOP, style.marginTop);
-      }
+      yogaNode.setMargin(yoga.EDGE_TOP, style.marginTop);
     }
     if (!isNullOrUndefined(style.marginBottom)) {
-      if (isPercent(style.marginBottom)) {
-        yogaNode.setMarginPercent(yoga.EDGE_BOTTOM, style.marginBottom);
-      } else if (isAuto(style.marginBottom)) {
-        yogaNode.setMarginAuto(yoga.EDGE_BOTTOM);
-      } else {
-        yogaNode.setMargin(yoga.EDGE_BOTTOM, style.marginBottom);
-      }
+      yogaNode.setMargin(yoga.EDGE_BOTTOM, style.marginBottom);
     }
     if (!isNullOrUndefined(style.marginLeft)) {
-      if (isPercent(style.marginLeft)) {
-        yogaNode.setMarginPercent(yoga.EDGE_LEFT, style.marginLeft);
-      } else if (isAuto(style.marginLeft)) {
-        yogaNode.setMarginAuto(yoga.EDGE_LEFT);
-      } else {
-        yogaNode.setMargin(yoga.EDGE_LEFT, style.marginLeft);
-      }
+      yogaNode.setMargin(yoga.EDGE_LEFT, style.marginLeft);
     }
     if (!isNullOrUndefined(style.marginRight)) {
-      if (isPercent(style.marginRight)) {
-        yogaNode.setMarginPercent(yoga.EDGE_RIGHT, style.marginRight);
-      } else if (isAuto(style.marginRight)) {
-        yogaNode.setMarginAuto(yoga.EDGE_RIGHT);
-      } else {
-        yogaNode.setMargin(yoga.EDGE_RIGHT, style.marginRight);
-      }
+      yogaNode.setMargin(yoga.EDGE_RIGHT, style.marginRight);
     }
     if (!isNullOrUndefined(style.marginVertical)) {
-      if (isPercent(style.marginVertical)) {
-        yogaNode.setMarginPercent(yoga.EDGE_VERTICAL, style.marginVertical);
-      } else if (isAuto(style.marginVertical)) {
-        yogaNode.setMarginAuto(yoga.EDGE_VERTICAL);
-      } else {
-        yogaNode.setMargin(yoga.EDGE_VERTICAL, style.marginVertical);
-      }
+      yogaNode.setMargin(yoga.EDGE_VERTICAL, style.marginVertical);
     }
     if (!isNullOrUndefined(style.marginHorizontal)) {
-      if (isPercent(style.marginHorizontal)) {
-        yogaNode.setMarginPercent(yoga.EDGE_HORIZONTAL, style.marginHorizontal);
-      } else if (isAuto(style.marginHorizontal)) {
-        yogaNode.setMarginAuto(yoga.EDGE_HORIZONTAL);
-      } else {
-        yogaNode.setMargin(yoga.EDGE_HORIZONTAL, style.marginHorizontal);
-      }
+      yogaNode.setMargin(yoga.EDGE_HORIZONTAL, style.marginHorizontal);
     }
     if (!isNullOrUndefined(style.margin)) {
-      if (isPercent(style.margin)) {
-        yogaNode.setMarginPercent(yoga.EDGE_ALL, style.margin);
-      } else if (isAuto(style.margin)) {
-        yogaNode.setMarginAuto(yoga.EDGE_ALL);
-      } else {
-        yogaNode.setMargin(yoga.EDGE_ALL, style.margin);
-      }
+      yogaNode.setMargin(yoga.EDGE_ALL, style.margin);
     }
 
     // Padding
     if (!isNullOrUndefined(style.paddingTop)) {
-      if (isPercent(style.paddingTop)) {
-        yogaNode.setPaddingPercent(yoga.EDGE_TOP, style.paddingTop);
-      } else {
-        yogaNode.setPadding(yoga.EDGE_TOP, style.paddingTop);
-      }
+      yogaNode.setPadding(yoga.EDGE_TOP, style.paddingTop);
     }
     if (!isNullOrUndefined(style.paddingBottom)) {
-      if (isPercent(style.paddingBottom)) {
-        yogaNode.setPaddingPercent(yoga.EDGE_BOTTOM, style.paddingBottom);
-      } else {
-        yogaNode.setPadding(yoga.EDGE_BOTTOM, style.paddingBottom);
-      }
+      yogaNode.setPadding(yoga.EDGE_BOTTOM, style.paddingBottom);
     }
     if (!isNullOrUndefined(style.paddingLeft)) {
-      if (isPercent(style.paddingLeft)) {
-        yogaNode.setPaddingPercent(yoga.EDGE_LEFT, style.paddingLeft);
-      } else {
-        yogaNode.setPadding(yoga.EDGE_LEFT, style.paddingLeft);
-      }
+      yogaNode.setPadding(yoga.EDGE_LEFT, style.paddingLeft);
     }
     if (!isNullOrUndefined(style.paddingRight)) {
-      if (isPercent(style.paddingRight)) {
-        yogaNode.setPaddingPercent(yoga.EDGE_RIGHT, style.paddingRight);
-      } else {
-        yogaNode.setPadding(yoga.EDGE_RIGHT, style.paddingRight);
-      }
+      yogaNode.setPadding(yoga.EDGE_RIGHT, style.paddingRight);
     }
     if (!isNullOrUndefined(style.paddingVertical)) {
-      if (isPercent(style.paddingVertical)) {
-        yogaNode.setPaddingPercent(yoga.EDGE_VERTICAL, style.paddingVertical);
-      } else {
-        yogaNode.setPadding(yoga.EDGE_VERTICAL, style.paddingVertical);
-      }
+      yogaNode.setPadding(yoga.EDGE_VERTICAL, style.paddingVertical);
     }
     if (!isNullOrUndefined(style.paddingHorizontal)) {
-      if (isPercent(style.paddingHorizontal)) {
-        yogaNode.setPaddingPercent(
-          yoga.EDGE_HORIZONTAL,
-          style.paddingHorizontal
-        );
-      } else {
-        yogaNode.setPadding(yoga.EDGE_HORIZONTAL, style.paddingHorizontal);
-      }
+      yogaNode.setPadding(yoga.EDGE_HORIZONTAL, style.paddingHorizontal);
     }
     if (!isNullOrUndefined(style.padding)) {
-      if (isPercent(style.padding)) {
-        yogaNode.setPaddingPercent(yoga.EDGE_ALL, style.padding);
-      } else {
-        yogaNode.setPadding(yoga.EDGE_ALL, style.padding);
-      }
+      yogaNode.setPadding(yoga.EDGE_ALL, style.padding);
     }
 
     // Border
@@ -258,32 +153,16 @@ const computeNode = (node: TreeNode, context: Context) => {
     }
 
     if (!isNullOrUndefined(style.top)) {
-      if (isPercent(style.top)) {
-        yogaNode.setPositionPercent(yoga.EDGE_TOP, style.top);
-      } else {
-        yogaNode.setPosition(yoga.EDGE_TOP, style.top);
-      }
+      yogaNode.setPosition(yoga.EDGE_TOP, style.top);
     }
     if (!isNullOrUndefined(style.left)) {
-      if (isPercent(style.left)) {
-        yogaNode.setPositionPercent(yoga.EDGE_LEFT, style.left);
-      } else {
-        yogaNode.setPosition(yoga.EDGE_LEFT, style.left);
-      }
+      yogaNode.setPosition(yoga.EDGE_LEFT, style.left);
     }
     if (!isNullOrUndefined(style.right)) {
-      if (isPercent(style.right)) {
-        yogaNode.setPositionPercent(yoga.EDGE_RIGHT, style.right);
-      } else {
-        yogaNode.setPosition(yoga.EDGE_RIGHT, style.right);
-      }
+      yogaNode.setPosition(yoga.EDGE_RIGHT, style.right);
     }
     if (!isNullOrUndefined(style.bottom)) {
-      if (isPercent(style.bottom)) {
-        yogaNode.setPositionPercent(yoga.EDGE_BOTTOM, style.bottom);
-      } else {
-        yogaNode.setPosition(yoga.EDGE_BOTTOM, style.bottom);
-      }
+      yogaNode.setPosition(yoga.EDGE_BOTTOM, style.bottom);
     }
 
     // Display

--- a/src/jsonUtils/computeNode.js
+++ b/src/jsonUtils/computeNode.js
@@ -23,7 +23,10 @@ const getStyles = (node: TreeNode): ViewStyle | Object => {
 
 const isNullOrUndefined = (value: any) => value === null || value === undefined;
 
-const computeNode = (node: TreeNode, context: Context) => {
+const computeNode = (
+  node: TreeNode,
+  context: Context
+): { node: yoga.NodeInstance, stop?: boolean } => {
   const yogaNode = yoga.Node.create();
   const hasStyle = node.props && node.props.style;
   const style: ViewStyle | Object = hasStyle ? getStyles(node) : {};
@@ -303,24 +306,29 @@ const computeNode = (node: TreeNode, context: Context) => {
     }
   }
 
-  if (typeof node === 'string') {
-    const textStyle = context.getInheritedStyles();
-    yogaNode.setMeasureFunc(createStringMeasurer(node, textStyle));
-    return yogaNode;
+  // if (typeof node === 'string') {
+  //   const textStyle = context.getInheritedStyles();
+  //   yogaNode.setMeasureFunc(createStringMeasurer(node, textStyle));
+  //   return yogaNode;
+  // }
+
+  if (node.type === 'text') {
+    // If current node is a Text node, add text styles to Context to pass down to
+    // child nodes.
+    if (node.props.style && hasAnyDefined(style, INHERITABLE_FONT_STYLES)) {
+      const inheritableStyles = pick(style, INHERITABLE_FONT_STYLES);
+      context.addInheritableStyles(inheritableStyles);
+    }
+
+    // Handle Text Children
+    if (node.children && node.children.length > 0) {
+      console.log(node.children);
+    }
+
+    return { node: yogaNode, stop: true };
   }
 
-  // If current node is a Text node, add text styles to Context to pass down to
-  // child nodes.
-  if (
-    node.type === 'text' &&
-    node.props.style &&
-    hasAnyDefined(style, INHERITABLE_FONT_STYLES)
-  ) {
-    const inheritableStyles = pick(style, INHERITABLE_FONT_STYLES);
-    context.addInheritableStyles(inheritableStyles);
-  }
-
-  return yogaNode;
+  return { node: yogaNode };
 };
 
 export default computeNode;

--- a/src/jsonUtils/computeNode.js
+++ b/src/jsonUtils/computeNode.js
@@ -30,7 +30,7 @@ const computeNode = (node: TreeNode, context: Context) => {
   if (hasStyle) {
     // http://facebook.github.io/react-native/releases/0.48/docs/layout-props.html
 
-    // Height & Width
+    // Width
     if (style.width) {
       if (isPercent(style.width)) {
         yogaNode.setWidthPercent(style.width);
@@ -40,6 +40,8 @@ const computeNode = (node: TreeNode, context: Context) => {
         yogaNode.setWidth(style.width);
       }
     }
+
+    // Height
     if (style.height) {
       if (isPercent(style.height)) {
         yogaNode.setHeightPercent(style.height);
@@ -50,6 +52,7 @@ const computeNode = (node: TreeNode, context: Context) => {
       }
     }
 
+    // Min-Height
     if (style.minHeight) {
       if (isPercent(style.minHeight)) {
         yogaNode.setMinHeightPercent(style.minHeight);
@@ -57,6 +60,8 @@ const computeNode = (node: TreeNode, context: Context) => {
         yogaNode.setMinHeight(style.minHeight);
       }
     }
+
+    // Min-Width
     if (style.minWidth) {
       if (isPercent(style.minWidth)) {
         yogaNode.setMinWidthPercent(style.minWidth);
@@ -65,6 +70,7 @@ const computeNode = (node: TreeNode, context: Context) => {
       }
     }
 
+    // Max-Height
     if (style.maxHeight) {
       if (isPercent(style.maxHeight)) {
         yogaNode.setMaxHeightPercent(style.maxHeight);
@@ -72,6 +78,8 @@ const computeNode = (node: TreeNode, context: Context) => {
         yogaNode.setMaxHeight(style.maxHeight);
       }
     }
+
+    // Min-Width
     if (style.maxWidth) {
       if (isPercent(style.maxWidth)) {
         yogaNode.setMaxWidthPercent(style.maxWidth);

--- a/src/jsonUtils/computeNode.js
+++ b/src/jsonUtils/computeNode.js
@@ -309,6 +309,8 @@ const computeNode = (node: TreeNode, context: Context) => {
     return yogaNode;
   }
 
+  // If current node is a Text node, add text styles to Context to pass down to
+  // child nodes.
   if (
     node.type === 'text' &&
     node.props.style &&

--- a/src/jsonUtils/computeTextTree.js
+++ b/src/jsonUtils/computeTextTree.js
@@ -8,7 +8,10 @@ const walkTextTree = (
   context: Context,
   textNodes: Array<Object>
 ) => {
-  if (!VALID_TEXT_CHILDREN_TYPES.includes(textTree.type)) {
+  if (
+    typeof textTree !== 'string' &&
+    !VALID_TEXT_CHILDREN_TYPES.includes(textTree.type)
+  ) {
     throw new Error(
       `"${textTree.type}" is not a valid child for Text components`
     );
@@ -22,7 +25,7 @@ const walkTextTree = (
   }
 
   if (textTree.children) {
-    if (textTree.props.style) {
+    if (textTree.props && textTree.props.style) {
       context.addInheritableStyles(textTree.props.style);
     }
     for (let index = 0; index < textTree.children.length; index += 1) {

--- a/src/jsonUtils/computeTextTree.js
+++ b/src/jsonUtils/computeTextTree.js
@@ -1,14 +1,14 @@
 // @flow
 import type { TreeNode } from '../types';
 import type Context from '../utils/Context';
-import { INVALID_TEXT_CHILDREN_TYPES } from '../utils/constants';
+import { VALID_TEXT_CHILDREN_TYPES } from '../utils/constants';
 
 const walkTextTree = (
   textTree: TreeNode,
   context: Context,
   textNodes: Array<Object>
 ) => {
-  if (INVALID_TEXT_CHILDREN_TYPES.includes(textTree.type)) {
+  if (!VALID_TEXT_CHILDREN_TYPES.includes(textTree.type)) {
     throw new Error(
       `"${textTree.type}" is not a valid child for Text components`
     );

--- a/src/jsonUtils/computeTextTree.js
+++ b/src/jsonUtils/computeTextTree.js
@@ -1,12 +1,19 @@
 // @flow
 import type { TreeNode } from '../types';
 import type Context from '../utils/Context';
+import { INVALID_TEXT_CHILDREN_TYPES } from '../utils/constants';
 
 const walkTextTree = (
   textTree: TreeNode,
   context: Context,
   textNodes: Array<Object>
 ) => {
+  if (INVALID_TEXT_CHILDREN_TYPES.includes(textTree.type)) {
+    throw new Error(
+      `"${textTree.type}" is not a valid child for Text components`
+    );
+  }
+
   if (typeof textTree === 'string') {
     textNodes.push({
       textStyles: context.getInheritedStyles(),

--- a/src/jsonUtils/computeTextTree.js
+++ b/src/jsonUtils/computeTextTree.js
@@ -1,0 +1,51 @@
+// @flow
+import type { TreeNode } from '../types';
+import type Context from '../utils/Context';
+
+const walkTextTree = (
+  textTree: TreeNode,
+  context: Context,
+  textNodes: Array<Object>
+) => {
+  if (typeof textTree === 'string') {
+    textNodes.push({
+      textStyles: context.getInheritedStyles(),
+      content: textTree,
+    });
+  }
+
+  if (textTree.children) {
+    if (textTree.props.style) {
+      context.addInheritableStyles(textTree.props.style);
+    }
+    for (let index = 0; index < textTree.children.length; index += 1) {
+      const textComponent = textTree.children[index];
+      walkTextTree(textComponent, context.forChildren(), textNodes);
+    }
+  }
+};
+
+const computeTextTree = (
+  node: TreeNode,
+  context: Context,
+  textNodes: Array<Object> = []
+) => {
+  if (node.children) {
+    const childContext = context.forChildren();
+    for (let index = 0; index < node.children.length; index += 1) {
+      const textNode = node.children[index];
+      if (typeof textNode === 'string') {
+        textNodes.push({
+          content: textNode,
+          textStyles: childContext.getInheritedStyles(),
+        });
+      } else if (textNode.children && textNode.children.length > 0) {
+        walkTextTree(textNode, childContext, textNodes);
+      }
+    }
+  }
+
+  return textNodes;
+};
+
+export default computeTextTree;

--- a/src/jsonUtils/computeTree.js
+++ b/src/jsonUtils/computeTree.js
@@ -3,7 +3,7 @@ import * as yoga from 'yoga-layout';
 import computeNode from './computeNode';
 import Context from '../utils/Context';
 
-const recurseTree = (tree: yoga.NodeInstance, context: Context) => {
+const walkTree = (tree: yoga.NodeInstance, context: Context) => {
   const node = computeNode(tree, context);
 
   if (tree.children) {
@@ -11,7 +11,7 @@ const recurseTree = (tree: yoga.NodeInstance, context: Context) => {
       const childComponent = tree.children[index];
       // Ignore Text nodes
       if (!(typeof childComponent === 'string')) {
-        const childNode = recurseTree(childComponent, context.forChildren());
+        const childNode = walkTree(childComponent, context.forChildren());
         node.insertChild(childNode, index);
       }
     }
@@ -20,6 +20,6 @@ const recurseTree = (tree: yoga.NodeInstance, context: Context) => {
   return node;
 };
 const treeToNodes = (root: yoga.NodeInstance, context: Context) =>
-  recurseTree(root, context);
+  walkTree(root, context);
 
 export default treeToNodes;

--- a/src/jsonUtils/computeTree.js
+++ b/src/jsonUtils/computeTree.js
@@ -1,14 +1,19 @@
 // @flow
 import * as yoga from 'yoga-layout';
 import computeNode from './computeNode';
+import type { TreeNode } from '../types';
 import Context from '../utils/Context';
+import zIndex from '../utils/zIndex';
 
-const walkTree = (tree: yoga.NodeInstance, context: Context) => {
+const walkTree = (tree: TreeNode, context: Context) => {
   const { node, stop } = computeNode(tree, context);
 
   if (tree.children && tree.children.length > 0) {
-    for (let index = 0; index < tree.children.length; index += 1) {
-      const childComponent = tree.children[index];
+    // Calculates zIndex order
+    const children = zIndex(tree.children, true);
+
+    for (let index = 0; index < children.length; index += 1) {
+      const childComponent = children[index];
       // Avoid going into <text> node's children
       if (!stop) {
         const childNode = walkTree(childComponent, context.forChildren());
@@ -19,7 +24,7 @@ const walkTree = (tree: yoga.NodeInstance, context: Context) => {
 
   return node;
 };
-const treeToNodes = (root: yoga.NodeInstance, context: Context) =>
+const treeToNodes = (root: TreeNode, context: Context): yoga.NodeInstance =>
   walkTree(root, context);
 
 export default treeToNodes;

--- a/src/jsonUtils/computeTree.js
+++ b/src/jsonUtils/computeTree.js
@@ -4,13 +4,16 @@ import computeNode from './computeNode';
 import Context from '../utils/Context';
 
 const walkTree = (tree: yoga.NodeInstance, context: Context) => {
-  const node = computeNode(tree, context);
+  const { node, stop } = computeNode(tree, context);
 
   if (tree.children) {
     for (let index = 0; index < tree.children.length; index += 1) {
       const childComponent = tree.children[index];
-      const childNode = walkTree(childComponent, context.forChildren());
-      node.insertChild(childNode, index);
+      // Avoid going into <text> node's children
+      if (!stop) {
+        const childNode = walkTree(childComponent, context.forChildren());
+        node.insertChild(childNode, index);
+      }
     }
   }
 

--- a/src/jsonUtils/computeTree.js
+++ b/src/jsonUtils/computeTree.js
@@ -1,0 +1,25 @@
+// @flow
+import * as yoga from 'yoga-layout';
+import computeNode from './computeNode';
+import Context from '../utils/Context';
+
+const recurseTree = (tree: yoga.NodeInstance, context: Context) => {
+  const node = computeNode(tree, context);
+
+  if (tree.children) {
+    for (let index = 0; index < tree.children.length; index += 1) {
+      const childComponent = tree.children[index];
+      // Ignore Text nodes
+      if (!(typeof childComponent === 'string')) {
+        const childNode = recurseTree(childComponent, context.forChildren());
+        node.insertChild(childNode, index);
+      }
+    }
+  }
+
+  return node;
+};
+const treeToNodes = (root: yoga.NodeInstance, context: Context) =>
+  recurseTree(root, context);
+
+export default treeToNodes;

--- a/src/jsonUtils/computeTree.js
+++ b/src/jsonUtils/computeTree.js
@@ -6,7 +6,7 @@ import Context from '../utils/Context';
 const walkTree = (tree: yoga.NodeInstance, context: Context) => {
   const { node, stop } = computeNode(tree, context);
 
-  if (tree.children) {
+  if (tree.children && tree.children.length > 0) {
     for (let index = 0; index < tree.children.length; index += 1) {
       const childComponent = tree.children[index];
       // Avoid going into <text> node's children

--- a/src/jsonUtils/computeTree.js
+++ b/src/jsonUtils/computeTree.js
@@ -9,11 +9,8 @@ const walkTree = (tree: yoga.NodeInstance, context: Context) => {
   if (tree.children) {
     for (let index = 0; index < tree.children.length; index += 1) {
       const childComponent = tree.children[index];
-      // Ignore Text nodes
-      if (!(typeof childComponent === 'string')) {
-        const childNode = walkTree(childComponent, context.forChildren());
-        node.insertChild(childNode, index);
-      }
+      const childNode = walkTree(childComponent, context.forChildren());
+      node.insertChild(childNode, index);
     }
   }
 

--- a/src/jsonUtils/computeYogaNode.js
+++ b/src/jsonUtils/computeYogaNode.js
@@ -279,7 +279,7 @@ const computeYogaNode = (
     // Align Self
     if (style.alignSelf) {
       if (style.alignSelf === 'flex-start') {
-        yogaNode.setAlignSelf(yoga.ALIGN_FLEX_END);
+        yogaNode.setAlignSelf(yoga.ALIGN_FLEX_START);
       }
       if (style.alignSelf === 'flex-end') {
         yogaNode.setAlignSelf(yoga.ALIGN_FLEX_END);

--- a/src/jsonUtils/computeYogaNode.js
+++ b/src/jsonUtils/computeYogaNode.js
@@ -7,10 +7,11 @@ import hasAnyDefined from '../utils/hasAnyDefined';
 import pick from '../utils/pick';
 import computeTextTree from './computeTextTree';
 import { INHERITABLE_FONT_STYLES } from '../utils/constants';
+import isNullOrUndefined from '../utils/isNullOrUndefined';
 import { getSymbolMasterByName } from '../symbol';
 
 // flatten all styles (including nested) into one object
-const getStyles = (node: TreeNode): ViewStyle | Object => {
+export const getStyles = (node: TreeNode): ViewStyle | Object => {
   let style = node.props.style;
 
   if (Array.isArray(style)) {
@@ -23,12 +24,10 @@ const getStyles = (node: TreeNode): ViewStyle | Object => {
   return style;
 };
 
-const isNullOrUndefined = (value: any) => value === null || value === undefined;
-
-const computeNode = (
+const computeYogaNode = (
   node: TreeNode,
   context: Context
-): { node: yoga.NodeInstance, stop?: boolean } => {
+): { node: TreeNode, stop?: boolean } => {
   const yogaNode = yoga.Node.create();
   const hasStyle = node.props && node.props.style;
   const style: ViewStyle | Object = hasStyle ? getStyles(node) : {};
@@ -334,4 +333,4 @@ const computeNode = (
   return { node: yogaNode };
 };
 
-export default computeNode;
+export default computeYogaNode;

--- a/src/jsonUtils/computeYogaNode.js
+++ b/src/jsonUtils/computeYogaNode.js
@@ -120,26 +120,20 @@ const computeYogaNode = (
     }
 
     // Border
-    if (!isNullOrUndefined(style.borderTop)) {
-      yogaNode.setBorder(yoga.EDGE_TOP, style.borderTop);
+    if (!isNullOrUndefined(style.borderTopWidth)) {
+      yogaNode.setBorder(yoga.EDGE_TOP, style.borderTopWidth);
     }
-    if (!isNullOrUndefined(style.borderBottom)) {
-      yogaNode.setBorder(yoga.EDGE_BOTTOM, style.borderBottom);
+    if (!isNullOrUndefined(style.borderBottomWidth)) {
+      yogaNode.setBorder(yoga.EDGE_BOTTOM, style.borderBottomWidth);
     }
-    if (!isNullOrUndefined(style.borderLeft)) {
-      yogaNode.setBorder(yoga.EDGE_LEFT, style.borderLeft);
+    if (!isNullOrUndefined(style.borderLeftWidth)) {
+      yogaNode.setBorder(yoga.EDGE_LEFT, style.borderLeftWidth);
     }
-    if (!isNullOrUndefined(style.borderRight)) {
-      yogaNode.setBorder(yoga.EDGE_RIGHT, style.borderRight);
+    if (!isNullOrUndefined(style.borderRightWidth)) {
+      yogaNode.setBorder(yoga.EDGE_RIGHT, style.borderRightWidth);
     }
-    if (!isNullOrUndefined(style.borderVertical)) {
-      yogaNode.setBorder(yoga.EDGE_VERTICAL, style.borderVertical);
-    }
-    if (!isNullOrUndefined(style.borderHorizontal)) {
-      yogaNode.setBorder(yoga.EDGE_HORIZONTAL, style.borderHorizontal);
-    }
-    if (!isNullOrUndefined(style.border)) {
-      yogaNode.setBorder(yoga.EDGE_ALL, style.border);
+    if (!isNullOrUndefined(style.borderWidth)) {
+      yogaNode.setBorder(yoga.EDGE_ALL, style.borderWidth);
     }
 
     // Flex

--- a/src/jsonUtils/computeYogaTree.js
+++ b/src/jsonUtils/computeYogaTree.js
@@ -1,16 +1,16 @@
 // @flow
 import * as yoga from 'yoga-layout';
-import computeNode from './computeNode';
+import computeYogaNode from './computeYogaNode';
 import type { TreeNode } from '../types';
 import Context from '../utils/Context';
 import zIndex from '../utils/zIndex';
 
 const walkTree = (tree: TreeNode, context: Context) => {
-  const { node, stop } = computeNode(tree, context);
+  const { node, stop } = computeYogaNode(tree, context);
 
   if (tree.children && tree.children.length > 0) {
     // Calculates zIndex order
-    const children = zIndex(tree.children, true);
+    const children = zIndex(tree.children);
 
     for (let index = 0; index < children.length; index += 1) {
       const childComponent = children[index];

--- a/src/jsonUtils/hacksForJSONImpl.js
+++ b/src/jsonUtils/hacksForJSONImpl.js
@@ -100,7 +100,7 @@ export const makeImageDataFromUrl = (url: string): MSImageData => {
 };
 
 // This shouldn't need to call into Sketch, but it does currently, which is bad for perf :(
-export function createStringAttributes(textStyles: TextStyle): Object {
+function createStringAttributes(textStyles: TextStyle): Object {
   const font = findFont(textStyles);
 
   const color = makeColorFromCSS(textStyles.color || 'black');

--- a/src/jsonUtils/hacksForJSONImpl.js
+++ b/src/jsonUtils/hacksForJSONImpl.js
@@ -47,6 +47,7 @@ function makeParagraphStyle(textStyle) {
   const pStyle = NSMutableParagraphStyle.alloc().init();
   if (textStyle.lineHeight !== undefined) {
     pStyle.minimumLineHeight = textStyle.lineHeight;
+    pStyle.lineHeightMultiple = 1.0;
     pStyle.maximumLineHeight = textStyle.lineHeight;
   }
 
@@ -98,8 +99,7 @@ export const makeImageDataFromUrl = (url: string): MSImageData => {
   return MSImageData.alloc().initWithImage(image);
 };
 
-function createString(textNode: TextNode): NSAttributedString {
-  const { content, textStyles } = textNode;
+export function createStringAttributes(textStyles: TextStyle): Object {
   const font = findFont(textStyles);
 
   const color = makeColorFromCSS(textStyles.color || 'black');
@@ -126,6 +126,14 @@ function createString(textNode: TextNode): NSAttributedString {
       TEXT_TRANSFORM[textStyles.textTransform] * 1;
   }
 
+  return attribs;
+}
+
+function createAttributedString(textNode: TextNode): NSAttributedString {
+  const { content, textStyles } = textNode;
+
+  const attribs = createStringAttributes(textStyles);
+
   return NSAttributedString.attributedStringWithString_attributes_(
     content,
     attribs
@@ -137,7 +145,7 @@ export function makeAttributedString(textNodes: TextNodes) {
   const fullStr = NSMutableAttributedString.alloc().init();
 
   textNodes.forEach((textNode) => {
-    const newString = createString(textNode);
+    const newString = createAttributedString(textNode);
     fullStr.appendAttributedString(newString);
   });
 

--- a/src/jsonUtils/hacksForJSONImpl.js
+++ b/src/jsonUtils/hacksForJSONImpl.js
@@ -106,6 +106,7 @@ export function createStringAttributes(textStyles: TextStyle): Object {
 
   const attribs: Object = {
     MSAttributedStringFontAttribute: font.fontDescriptor(),
+    NSFont: font,
     NSParagraphStyle: makeParagraphStyle(textStyles),
     NSColor: NSColor.colorWithDeviceRed_green_blue_alpha(
       color.red,
@@ -129,7 +130,7 @@ export function createStringAttributes(textStyles: TextStyle): Object {
   return attribs;
 }
 
-function createAttributedString(textNode: TextNode): NSAttributedString {
+export function createAttributedString(textNode: TextNode): NSAttributedString {
   const { content, textStyles } = textNode;
 
   const attribs = createStringAttributes(textStyles);
@@ -141,7 +142,7 @@ function createAttributedString(textNode: TextNode): NSAttributedString {
 }
 
 // This shouldn't need to call into Sketch, but it does currently, which is bad for perf :(
-export function makeAttributedString(textNodes: TextNodes) {
+export function makeEncodedAttributedString(textNodes: TextNodes) {
   const fullStr = NSMutableAttributedString.alloc().init();
 
   textNodes.forEach((textNode) => {
@@ -167,6 +168,7 @@ export function makeTextStyle(textStyle: TextStyle) {
     _class: 'textStyle',
     encodedAttributes: {
       MSAttributedStringFontAttribute: encodeSketchJSON(font.fontDescriptor()),
+      NSFont: font,
       NSColor: encodeSketchJSON(
         NSColor.colorWithDeviceRed_green_blue_alpha(
           color.red,

--- a/src/jsonUtils/hacksForJSONImpl.js
+++ b/src/jsonUtils/hacksForJSONImpl.js
@@ -4,7 +4,7 @@ import type { SJTextStyle } from 'sketchapp-json-flow-types';
 import { TextAlignment } from 'sketch-constants';
 import { toSJSON } from 'sketchapp-json-plugin';
 import findFont from '../utils/findFont';
-import type { TextStyle } from '../types';
+import type { TextNodes, TextNode, TextStyle } from '../types';
 import { generateID, makeColorFromCSS } from './models';
 
 export const TEXT_ALIGN = {
@@ -98,40 +98,51 @@ export const makeImageDataFromUrl = (url: string): MSImageData => {
   return MSImageData.alloc().initWithImage(image);
 };
 
-// This shouldn't need to call into Sketch, but it does currently, which is bad for perf :(
-export function makeAttributedString(string: ?string, textStyle: TextStyle) {
-  const font = findFont(textStyle);
+function createString(textNode: TextNode): NSAttributedString {
+  const { content, textStyles } = textNode;
+  const font = findFont(textStyles);
 
-  const color = makeColorFromCSS(textStyle.color || 'black');
+  const color = makeColorFromCSS(textStyles.color || 'black');
 
   const attribs: Object = {
     MSAttributedStringFontAttribute: font.fontDescriptor(),
-    NSParagraphStyle: makeParagraphStyle(textStyle),
+    NSParagraphStyle: makeParagraphStyle(textStyles),
     NSColor: NSColor.colorWithDeviceRed_green_blue_alpha(
       color.red,
       color.green,
       color.blue,
       color.alpha
     ),
-    NSUnderline: TEXT_DECORATION_UNDERLINE[textStyle.textDecoration] || 0,
-    NSStrikethrough: TEXT_DECORATION_LINETHROUGH[textStyle.textDecoration] || 0,
+    NSUnderline: TEXT_DECORATION_UNDERLINE[textStyles.textDecoration] || 0,
+    NSStrikethrough: TEXT_DECORATION_LINETHROUGH[textStyles.textDecoration] || 0,
   };
 
-  if (textStyle.letterSpacing !== undefined) {
-    attribs.NSKern = textStyle.letterSpacing;
+  if (textStyles.letterSpacing !== undefined) {
+    attribs.NSKern = textStyles.letterSpacing;
   }
 
-  if (textStyle.textTransform !== undefined) {
+  if (textStyles.textTransform !== undefined) {
     attribs.MSAttributedStringTextTransformAttribute =
-      TEXT_TRANSFORM[textStyle.textTransform] * 1;
+      TEXT_TRANSFORM[textStyles.textTransform] * 1;
   }
 
-  const attribStr = NSAttributedString.attributedStringWithString_attributes_(
-    string,
+  return NSAttributedString.attributedStringWithString_attributes_(
+    content,
     attribs
   );
+}
+
+// This shouldn't need to call into Sketch, but it does currently, which is bad for perf :(
+export function makeAttributedString(textNodes: TextNodes) {
+  const fullStr = NSMutableAttributedString.alloc().init();
+
+  textNodes.forEach((textNode) => {
+    const newString = createString(textNode);
+    fullStr.appendAttributedString(newString);
+  });
+
   const msAttribStr = MSAttributedString.alloc().initWithAttributedString(
-    attribStr
+    fullStr
   );
 
   return encodeSketchJSON(msAttribStr);

--- a/src/jsonUtils/hacksForJSONImpl.js
+++ b/src/jsonUtils/hacksForJSONImpl.js
@@ -99,6 +99,7 @@ export const makeImageDataFromUrl = (url: string): MSImageData => {
   return MSImageData.alloc().initWithImage(image);
 };
 
+// This shouldn't need to call into Sketch, but it does currently, which is bad for perf :(
 export function createStringAttributes(textStyles: TextStyle): Object {
   const font = findFont(textStyles);
 
@@ -141,7 +142,6 @@ export function createAttributedString(textNode: TextNode): NSAttributedString {
   );
 }
 
-// This shouldn't need to call into Sketch, but it does currently, which is bad for perf :(
 export function makeEncodedAttributedString(textNodes: TextNodes) {
   const fullStr = NSMutableAttributedString.alloc().init();
 

--- a/src/jsonUtils/textLayers.js
+++ b/src/jsonUtils/textLayers.js
@@ -1,10 +1,14 @@
 /* @flow */
 import type { SJRect, SJTextLayer } from 'sketchapp-json-flow-types';
 import { makeAttributedString } from './hacksForJSONImpl';
-import type { TextStyle } from '../types';
+import type { TextNode } from '../types';
 import { generateID } from './models';
 
-const makeTextLayer = (frame: SJRect, text: string = '', textStyle: TextStyle): SJTextLayer => ({
+const makeTextLayer = (
+  frame: SJRect,
+  name: string,
+  textNodes: TextNode
+): SJTextLayer => ({
   _class: 'text',
   do_objectID: generateID(),
   frame,
@@ -13,12 +17,12 @@ const makeTextLayer = (frame: SJRect, text: string = '', textStyle: TextStyle): 
   isLocked: false,
   isVisible: true,
   layerListExpandedType: 0,
-  name: text,
+  name,
   nameIsFixed: false,
   resizingType: 0,
   rotation: 0,
   shouldBreakMaskChain: false,
-  attributedString: makeAttributedString(text, textStyle),
+  attributedString: makeAttributedString(textNodes),
   automaticallyDrawOnUnderlyingPath: false,
   dontSynchroniseWithSymbol: false,
   // NOTE(akp): I haven't fully figured out the meaning of glyphBounds

--- a/src/jsonUtils/textLayers.js
+++ b/src/jsonUtils/textLayers.js
@@ -1,6 +1,6 @@
 /* @flow */
 import type { SJRect, SJTextLayer } from 'sketchapp-json-flow-types';
-import { makeAttributedString } from './hacksForJSONImpl';
+import { makeEncodedAttributedString } from './hacksForJSONImpl';
 import type { TextNode } from '../types';
 import { generateID } from './models';
 
@@ -22,7 +22,7 @@ const makeTextLayer = (
   resizingType: 0,
   rotation: 0,
   shouldBreakMaskChain: false,
-  attributedString: makeAttributedString(textNodes),
+  attributedString: makeEncodedAttributedString(textNodes),
   automaticallyDrawOnUnderlyingPath: false,
   dontSynchroniseWithSymbol: false,
   // NOTE(akp): I haven't fully figured out the meaning of glyphBounds

--- a/src/renderers/ArtboardRenderer.js
+++ b/src/renderers/ArtboardRenderer.js
@@ -9,9 +9,7 @@ class ArtboardRenderer extends SketchRenderer {
     layout: LayoutInfo,
     style: ViewStyle,
     textStyle: TextStyle,
-    props: any,
-    // eslint-disable-next-line no-unused-vars
-    value: ?string
+    props: any
   ): SJArtboardLayer {
     let color;
     if (style.backgroundColor !== undefined) {

--- a/src/renderers/ImageRenderer.js
+++ b/src/renderers/ImageRenderer.js
@@ -27,7 +27,12 @@ const TRANSPARENT = 'transparent';
 const DEFAULT_BORDER_COLOR = TRANSPARENT;
 const DEFAULT_BORDER_STYLE = 'solid';
 
-const SHADOW_STYLES = ['shadowColor', 'shadowOffset', 'shadowOpacity', 'shadowRadius'];
+const SHADOW_STYLES = [
+  'shadowColor',
+  'shadowOffset',
+  'shadowOpacity',
+  'shadowRadius',
+];
 
 function extractURLFromSource(source) {
   if (typeof source === 'string') {
@@ -41,9 +46,7 @@ class ImageRenderer extends SketchRenderer {
     layout: LayoutInfo,
     style: ViewStyle,
     textStyle: TextStyle,
-    props: any,
-    // eslint-disable-next-line no-unused-vars
-    value: ?string
+    props: any
   ): Array<SJShapeGroupLayer> {
     const layers = [];
 
@@ -80,7 +83,13 @@ class ImageRenderer extends SketchRenderer {
       borderBottomRightRadius,
       borderBottomLeftRadius,
     ];
-    const shapeLayer = makeRectShapeLayer(0, 0, layout.width, layout.height, radii);
+    const shapeLayer = makeRectShapeLayer(
+      0,
+      0,
+      layout.width,
+      layout.height,
+      radii
+    );
 
     const fills = [makeImageFill(fillImage, PatternFillType[props.resizeMode])];
 
@@ -95,8 +104,18 @@ class ImageRenderer extends SketchRenderer {
     }
 
     if (
-      same(borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth) &&
-      same(borderTopColor, borderRightColor, borderBottomColor, borderLeftColor) &&
+      same(
+        borderTopWidth,
+        borderRightWidth,
+        borderBottomWidth,
+        borderLeftWidth
+      ) &&
+      same(
+        borderTopColor,
+        borderRightColor,
+        borderBottomColor,
+        borderLeftColor
+      ) &&
       same(borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle)
     ) {
       // all sides have same border width
@@ -126,7 +145,13 @@ class ImageRenderer extends SketchRenderer {
       layers.push(content);
 
       if (borderTopWidth > 0) {
-        const topBorder = makeHorizontalBorder(0, 0, layout.width, borderTopWidth, borderTopColor);
+        const topBorder = makeHorizontalBorder(
+          0,
+          0,
+          layout.width,
+          borderTopWidth,
+          borderTopColor
+        );
         topBorder.name = 'Border (top)';
 
         const borderOptions = makeBorderOptions(borderTopStyle, borderTopWidth);
@@ -147,7 +172,10 @@ class ImageRenderer extends SketchRenderer {
         );
         rightBorder.name = 'Border (right)';
 
-        const borderOptions = makeBorderOptions(borderRightStyle, borderRightWidth);
+        const borderOptions = makeBorderOptions(
+          borderRightStyle,
+          borderRightWidth
+        );
         if (borderOptions) {
           rightBorder.style.borderOptions = borderOptions;
         }
@@ -165,7 +193,10 @@ class ImageRenderer extends SketchRenderer {
         );
         bottomBorder.name = 'Border (bottom)';
 
-        const borderOptions = makeBorderOptions(borderBottomStyle, borderBottomWidth);
+        const borderOptions = makeBorderOptions(
+          borderBottomStyle,
+          borderBottomWidth
+        );
         if (borderOptions) {
           bottomBorder.style.borderOptions = borderOptions;
         }
@@ -183,7 +214,10 @@ class ImageRenderer extends SketchRenderer {
         );
         leftBorder.name = 'Border (left)';
 
-        const borderOptions = makeBorderOptions(borderLeftStyle, borderLeftWidth);
+        const borderOptions = makeBorderOptions(
+          borderLeftStyle,
+          borderLeftWidth
+        );
         if (borderOptions) {
           leftBorder.style.borderOptions = borderOptions;
         }

--- a/src/renderers/SketchRenderer.js
+++ b/src/renderers/SketchRenderer.js
@@ -7,9 +7,8 @@ const DEFAULT_OPACITY = 1.0;
 
 class SketchRenderer {
   getDefaultGroupName(
-    props: any,
     // eslint-disable-next-line no-unused-vars
-    value: ?string,
+    props: any
   ) {
     return 'Group';
   }
@@ -17,9 +16,7 @@ class SketchRenderer {
     layout: LayoutInfo,
     style: ViewStyle,
     textStyle: TextStyle,
-    props: any,
-    // eslint-disable-next-line no-unused-vars
-    value: ?string,
+    props: any
   ): SketchJSON {
     // Default SketchRenderer just renders an empty group
 
@@ -28,9 +25,8 @@ class SketchRenderer {
     //   processTransform(layer, layout, style.transform);
     // }
 
-    const opacity = style.opacity !== undefined
-      ? style.opacity
-      : DEFAULT_OPACITY;
+    const opacity =
+      style.opacity !== undefined ? style.opacity : DEFAULT_OPACITY;
 
     return {
       ...layerGroup(
@@ -38,18 +34,17 @@ class SketchRenderer {
         layout.top,
         layout.width,
         layout.height,
-        opacity,
+        opacity
       ),
-      name: props.name || this.getDefaultGroupName(props, value),
+      name: props.name || this.getDefaultGroupName(props),
     };
   }
   renderBackingLayers(
     layout: LayoutInfo,
     style: ViewStyle,
     textStyle: TextStyle,
-    props: any,
     // eslint-disable-next-line no-unused-vars
-    value: ?string,
+    props: any
   ): Array<SketchJSON> {
     return [];
   }

--- a/src/renderers/SymbolInstanceRenderer.js
+++ b/src/renderers/SymbolInstanceRenderer.js
@@ -43,9 +43,10 @@ const extractOverridesHelp = (subLayer: any, output: any) => {
     // that contains text. this is the structure that will appear if the user
     // creates a `<Text />` element with a custom name
     const subGroup = subLayer.layers.find(l => l._class === 'group');
-    const textLayer = subGroup && subGroup.layers
-      ? subGroup.layers.find(l => l._class === 'text')
-      : null;
+    const textLayer =
+      subGroup && subGroup.layers
+        ? subGroup.layers.find(l => l._class === 'text')
+        : null;
     if (textLayer) {
       output.push({
         type: 'text',
@@ -92,7 +93,7 @@ const extractOverridesHelp = (subLayer: any, output: any) => {
     subLayer.layers
   ) {
     subLayer.layers.forEach(subSubLayer =>
-      extractOverridesHelp(subSubLayer, output),
+      extractOverridesHelp(subSubLayer, output)
     );
   }
 };
@@ -108,16 +109,14 @@ class SymbolInstanceRenderer extends SketchRenderer {
     layout: LayoutInfo,
     style: ViewStyle,
     textStyle: TextStyle,
-    props: any,
-    // eslint-disable-next-line no-unused-vars
-    value: ?string,
+    props: any
   ): any {
     const masterTree = getSymbolMasterByName(props.masterName);
 
     const symbolInstance = makeSymbolInstance(
       makeRect(layout.left, layout.top, layout.width, layout.height),
       masterTree.symbolID,
-      props.name,
+      props.name
     );
 
     if (!props.overrides) {
@@ -128,7 +127,7 @@ class SymbolInstanceRenderer extends SketchRenderer {
 
     const overrides = overridableLayers.reduce(function inject(
       memo,
-      reference,
+      reference
     ) {
       if (reference.type === 'symbolInstance') {
         // eslint-disable-next-line
@@ -139,13 +138,13 @@ class SymbolInstanceRenderer extends SketchRenderer {
             typeof overrideValue.masterName !== 'string'
           ) {
             throw new Error(
-              '##FIXME## SYMBOL INSTANCE SUBSTITUTIONS MUST BE PASSED THE CONSTRUCTOR OF THE OTHER SYMBOL',
+              '##FIXME## SYMBOL INSTANCE SUBSTITUTIONS MUST BE PASSED THE CONSTRUCTOR OF THE OTHER SYMBOL'
             );
           }
 
           const originalMaster = getSymbolMasterById(reference.symbolId);
           const replacementMaster = getSymbolMasterByName(
-            overrideValue.masterName,
+            overrideValue.masterName
           );
 
           if (
@@ -153,12 +152,12 @@ class SymbolInstanceRenderer extends SketchRenderer {
             originalMaster.frame.height !== replacementMaster.frame.height
           ) {
             throw new Error(
-              '##FIXME## SYMBOL MASTER SUBSTITUTIONS REQUIRE THAT MASTERS HAVE THE SAME DIMENSIONS',
+              '##FIXME## SYMBOL MASTER SUBSTITUTIONS REQUIRE THAT MASTERS HAVE THE SAME DIMENSIONS'
             );
           }
 
           const nestedOverrides = extractOverrides(
-            getSymbolMasterByName(overrideValue.masterName).layers,
+            getSymbolMasterByName(overrideValue.masterName).layers
           ).reduce(inject, {});
 
           return {
@@ -171,7 +170,7 @@ class SymbolInstanceRenderer extends SketchRenderer {
         }
 
         const nestedOverrides = extractOverrides(
-          getSymbolMasterById(reference.symbolId).layers,
+          getSymbolMasterById(reference.symbolId).layers
         ).reduce(inject, {});
 
         return {
@@ -197,13 +196,13 @@ class SymbolInstanceRenderer extends SketchRenderer {
       if (reference.type === 'image') {
         if (typeof overrideValue !== 'string') {
           throw new Error(
-            '##FIXME"" IMAGE OVERRIDE VALUES MUST BE VALID IMAGE HREFS',
+            '##FIXME"" IMAGE OVERRIDE VALUES MUST BE VALID IMAGE HREFS'
           );
         }
         return {
           ...memo,
           [reference.objectId]: makeJSONDataReference(
-            makeImageDataFromUrl(overrideValue),
+            makeImageDataFromUrl(overrideValue)
           ),
         };
       }

--- a/src/renderers/SymbolMasterRenderer.js
+++ b/src/renderers/SymbolMasterRenderer.js
@@ -9,9 +9,7 @@ class SymbolMasterRenderer extends SketchRenderer {
     layout: LayoutInfo,
     style: ViewStyle,
     textStyle: TextStyle,
-    props: any,
-    // eslint-disable-next-line no-unused-vars
-    value: ?string
+    props: any
   ): SJSymbolMaster {
     return makeSymbolMaster(
       makeRect(layout.left, layout.top, layout.width, layout.height),

--- a/src/renderers/TextRenderer.js
+++ b/src/renderers/TextRenderer.js
@@ -1,6 +1,5 @@
 /* @flow */
 import SketchRenderer from './SketchRenderer';
-import ViewRenderer from './ViewRenderer';
 import type { SketchLayer, ViewStyle, LayoutInfo, TextStyle } from '../types';
 import makeTextLayer from '../jsonUtils/textLayers';
 import { makeRect } from '../jsonUtils/models';
@@ -22,17 +21,6 @@ class TextRenderer extends SketchRenderer {
       props.textNodes.forEach((textNode) => {
         name += textNode.content;
       });
-    }
-
-    if (name === '') {
-      const viewRenderer = new ViewRenderer();
-      return viewRenderer.renderBackingLayers(
-        layout,
-        style,
-        textStyle,
-        props,
-        name
-      );
     }
 
     const frame = makeRect(0, 0, layout.width, layout.height);

--- a/src/renderers/TextRenderer.js
+++ b/src/renderers/TextRenderer.js
@@ -18,9 +18,12 @@ class TextRenderer extends SketchRenderer {
   ): Array<SketchLayer> {
     // Append all text nodes's content into one string
     let name = '';
-    props.textNodes.forEach((textNode) => {
-      name += textNode.content;
-    });
+    if (props.textNodes) {
+      props.textNodes.forEach((textNode) => {
+        name += textNode.content;
+      });
+    }
+
     if (name === '') {
       const viewRenderer = new ViewRenderer();
       return viewRenderer.renderBackingLayers(

--- a/src/renderers/TextRenderer.js
+++ b/src/renderers/TextRenderer.js
@@ -7,31 +7,33 @@ import { makeRect } from '../jsonUtils/models';
 import TextStyles from '../sharedStyles/TextStyles';
 
 class TextRenderer extends SketchRenderer {
-  getDefaultGroupName(props: any, value: ?string) {
-    return value || 'Text';
+  getDefaultGroupName(props: any) {
+    return props.name || 'Text';
   }
   renderBackingLayers(
     layout: LayoutInfo,
     style: ViewStyle,
     textStyle: TextStyle,
-    props: any,
-    value: ?string
+    props: any
   ): Array<SketchLayer> {
-    if (value === null) {
+    // Append all text nodes's content into one string
+    let name = '';
+    props.textNodes.forEach((textNode) => {
+      name += textNode.content;
+    });
+    if (name === '') {
       const viewRenderer = new ViewRenderer();
       return viewRenderer.renderBackingLayers(
         layout,
         style,
         textStyle,
         props,
-        value
+        name
       );
     }
 
-    console.log(props.textNodes);
-
     const frame = makeRect(0, 0, layout.width, layout.height);
-    const layer = makeTextLayer(frame, value, textStyle);
+    const layer = makeTextLayer(frame, name, props.textNodes);
 
     const resolvedStyle = TextStyles.resolve(textStyle);
     if (resolvedStyle) {

--- a/src/renderers/TextRenderer.js
+++ b/src/renderers/TextRenderer.js
@@ -15,12 +15,20 @@ class TextRenderer extends SketchRenderer {
     style: ViewStyle,
     textStyle: TextStyle,
     props: any,
-    value: ?string,
+    value: ?string
   ): Array<SketchLayer> {
     if (value === null) {
       const viewRenderer = new ViewRenderer();
-      return viewRenderer.renderBackingLayers(layout, style, textStyle, props, value);
+      return viewRenderer.renderBackingLayers(
+        layout,
+        style,
+        textStyle,
+        props,
+        value
+      );
     }
+
+    console.log(props.textNodes);
 
     const frame = makeRect(0, 0, layout.width, layout.height);
     const layer = makeTextLayer(frame, value, textStyle);

--- a/src/renderers/ViewRenderer.js
+++ b/src/renderers/ViewRenderer.js
@@ -4,7 +4,6 @@ import type { SJShapeGroupLayer } from 'sketchapp-json-flow-types';
 import SketchRenderer from './SketchRenderer';
 import { makeRect, makeColorFill, makeColorFromCSS } from '../jsonUtils/models';
 import { makeRectShapeLayer, makeShapeGroup } from '../jsonUtils/shapeLayers';
-// import processTransform from './processTransform';
 import type { ViewStyle, LayoutInfo, TextStyle } from '../types';
 import {
   makeBorderOptions,
@@ -60,9 +59,8 @@ class ViewRenderer extends SketchRenderer {
     layout: LayoutInfo,
     style: ViewStyle,
     textStyle: TextStyle,
-    props: any,
     // eslint-disable-next-line no-unused-vars
-    value: ?string
+    props: any
   ): Array<SJShapeGroupLayer> {
     const layers = [];
     // NOTE(lmr): the group handles the position, so we just care about width/height here

--- a/src/sharedStyles/TextStyles.js
+++ b/src/sharedStyles/TextStyles.js
@@ -7,25 +7,10 @@ import hashStyle from '../utils/hashStyle';
 import sharedTextStyles from '../wrappers/sharedTextStyles';
 import { makeTextStyle } from '../jsonUtils/hacksForJSONImpl';
 import pick from '../utils/pick';
+import { INHERITABLE_FONT_STYLES } from '../utils/constants';
 
 type MurmurHash = number;
 type SketchObjectID = string;
-// stored styles
-const INHERITABLE_STYLES = [
-  'color',
-  'fontFamily',
-  'fontSize',
-  'fontStyle',
-  'fontWeight',
-  'textShadowOffset',
-  'textShadowRadius',
-  'textShadowColor',
-  'textTransform',
-  'letterSpacing',
-  'lineHeight',
-  'textAlign',
-  'writingDirection',
-];
 
 type StyleHash = { [key: MurmurHash]: SketchStyle };
 
@@ -33,14 +18,14 @@ type RegisteredStyle = {|
   cssStyle: TextStyle,
   name: string,
   sketchStyle: SJStyle,
-  sharedObjectID: SketchObjectID,
+  sharedObjectID: SketchObjectID
 |};
 
 let _styles: StyleHash = {};
 const _byName: { [key: string]: MurmurHash } = {};
 
 const registerStyle = (name: string, style: TextStyle): void => {
-  const safeStyle = pick(style, INHERITABLE_STYLES);
+  const safeStyle = pick(style, INHERITABLE_FONT_STYLES);
   const hash = hashStyle(safeStyle);
   const sketchStyle = makeTextStyle(safeStyle);
   const sharedObjectID = sharedTextStyles.addStyle(name, sketchStyle);
@@ -58,10 +43,13 @@ const registerStyle = (name: string, style: TextStyle): void => {
 
 type Options = {
   clearExistingStyles?: boolean,
-  context: SketchContext,
+  context: SketchContext
 };
 
-const create = (options: Options, styles: { [key: string]: TextStyle }): StyleHash => {
+const create = (
+  options: Options,
+  styles: { [key: string]: TextStyle }
+): StyleHash => {
   const { clearExistingStyles, context } = options;
 
   if (!appVersionSupported()) {

--- a/src/types.js
+++ b/src/types.js
@@ -54,7 +54,7 @@ export type Size = { width: number, height: number };
 // undefined: max content
 // exactly: fill available space
 // at-most: fit content
-export type MeasureMode = 'undefined' | 'exactly' | 'at-most';
+export type MeasureMode = "undefined" | "exactly" | "at-most";
 
 export type Color = string | number;
 
@@ -65,7 +65,7 @@ export type LayoutInfo = {
   left: number,
   right: number,
   bottom: number,
-  direction: 'ltr' | 'rtl'
+  direction: "ltr" | "rtl"
 };
 
 export type ViewStyle = {
@@ -102,20 +102,25 @@ export type ViewStyle = {
   borderRightWidth: number,
   borderBottomWidth: number,
   borderLeftWidth: number,
-  position: 'absolute' | 'relative',
-  flexDirection: 'row' | 'row-reverse' | 'column' | 'column-reverse',
-  flexWrap: 'wrap' | 'nowrap',
-  justifyContent: 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around',
-  alignItems: 'flex-start' | 'flex-end' | 'center' | 'stretch',
-  alignSelf: 'auto' | 'flex-start' | 'flex-end' | 'center' | 'stretch',
-  overflow: 'visible' | 'hidden' | 'scroll',
+  position: "absolute" | "relative",
+  flexDirection: "row" | "row-reverse" | "column" | "column-reverse",
+  flexWrap: "wrap" | "nowrap",
+  justifyContent:
+    | "flex-start"
+    | "flex-end"
+    | "center"
+    | "space-between"
+    | "space-around",
+  alignItems: "flex-start" | "flex-end" | "center" | "stretch",
+  alignSelf: "auto" | "flex-start" | "flex-end" | "center" | "stretch",
+  overflow: "visible" | "hidden" | "scroll",
   flex: number,
   flexGrow: number,
   flexShrink: number,
   flexBasis: number,
   aspectRatio: number,
   zIndex: number,
-  backfaceVisibility: 'visible' | 'hidden',
+  backfaceVisibility: "visible" | "hidden",
   backgroundColor: Color,
   borderColor: Color,
   borderTopColor: Color,
@@ -127,7 +132,7 @@ export type ViewStyle = {
   borderTopRightRadius: number,
   borderBottomLeftRadius: number,
   borderBottomRightRadius: number,
-  borderStyle: 'solid' | 'dotted' | 'dashed',
+  borderStyle: "solid" | "dotted" | "dashed",
   borderWidth: number,
   borderTopWidth: number,
   borderRightWidth: number,
@@ -140,24 +145,26 @@ export type TextStyle = {
   color: Color,
   fontFamily: string,
   fontSize: number,
-  fontStyle: 'normal' | 'italic',
+  fontStyle: "normal" | "italic",
   fontWeight: string,
   textShadowOffset: { width: number, height: number },
   textShadowRadius: number,
   textShadowColor: Color,
-  textTransform: 'uppercase' | 'lowercase',
+  textTransform: "uppercase" | "lowercase",
   letterSpacing: number,
   lineHeight: number,
-  textAlign: 'auto' | 'left' | 'right' | 'center' | 'justify',
-  writingDirection: 'auto' | 'ltr' | 'rtl'
+  textAlign: "auto" | "left" | "right" | "center" | "justify",
+  writingDirection: "auto" | "ltr" | "rtl"
 };
+
+export type TextNode = { content: string, textStyles: TextStyle };
+export type TextNodes = Array<TextNode>;
 
 export type TreeNode = {
   type: string,
   style: ViewStyle,
   textStyle: TextStyle,
   layout: LayoutInfo,
-  value: ?string,
   props: any,
   children: ?Array<TreeNode>
 };

--- a/src/utils/Context.js
+++ b/src/utils/Context.js
@@ -21,4 +21,4 @@ class Context {
   }
 }
 
-module.exports = Context;
+export default Context;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -8,3 +8,37 @@ export const PatternFillType = {
   Stretch: 2,
   Fit: 3,
 };
+
+export const INHERITABLE_FONT_STYLES = [
+  'color',
+  'fontFamily',
+  'fontSize',
+  'fontStyle',
+  'fontWeight',
+  'textAlign',
+  'textDecoration',
+  'textShadowOffset',
+  'textShadowRadius',
+  'textShadowColor',
+  'textTransform',
+  'letterSpacing',
+  'lineHeight',
+  'writingDirection',
+];
+
+export const SKETCH_TREE_OBJECT_STUB = {
+  type: null,
+  style: {},
+  layout: {
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+    width: 0,
+    height: 0,
+  },
+  textStyle: {},
+  props: {},
+  value: null,
+  children: [],
+};

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -26,28 +26,8 @@ export const INHERITABLE_FONT_STYLES = [
   'writingDirection',
 ];
 
-export const SKETCH_TREE_OBJECT_STUB = {
-  type: null,
-  style: {},
-  layout: {
-    left: 0,
-    right: 0,
-    top: 0,
-    bottom: 0,
-    width: 0,
-    height: 0,
-  },
-  textStyle: {},
-  props: {},
-  value: null,
-  children: [],
-};
+// Only components that are allowed as children of <Text> components
+export const VALID_TEXT_CHILDREN_TYPES = ['text'];
 
-// Components that are not allowed within <Text> components
-export const INVALID_TEXT_CHILDREN_TYPES = [
-  'image',
-  'artboard',
-  'view',
-  'document',
-  'page',
-];
+// Font displayed if San Francisco fonts are not found
+export const APPLE_BROKEN_SYSTEM_FONT = '.AppleSystemUIFont';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -42,3 +42,12 @@ export const SKETCH_TREE_OBJECT_STUB = {
   value: null,
   children: [],
 };
+
+// Components that are not allowed within <Text> components
+export const INVALID_TEXT_CHILDREN_TYPES = [
+  'image',
+  'artboard',
+  'view',
+  'document',
+  'page',
+];

--- a/src/utils/createStringMeasurer.js
+++ b/src/utils/createStringMeasurer.js
@@ -36,4 +36,4 @@ const createStringMeasurer = (textNodes: TextNodes) => (
   return { width: newWidth, height: newHeight };
 };
 
-module.exports = createStringMeasurer;
+export default createStringMeasurer;

--- a/src/utils/createStringMeasurer.js
+++ b/src/utils/createStringMeasurer.js
@@ -5,9 +5,11 @@ import findFont from './findFont';
 // TODO(lmr): do something more sensible here
 const FLOAT_MAX = 999999;
 
-const measureString = (textNode: TextNode, width: number) => {
+const measureString = (textNode: TextNode) => {
   const { content, textStyles } = textNode;
+
   const font = findFont(textStyles);
+
   const attributes = {
     [NSFontAttributeName]: font,
   };
@@ -29,7 +31,7 @@ const measureString = (textNode: TextNode, width: number) => {
   const rect = NSString.alloc()
     .initWithString(content)
     .boundingRectWithSize_options_attributes_context(
-      CGSizeMake(width, FLOAT_MAX),
+      CGSizeMake(0, FLOAT_MAX),
       NSStringDrawingUsesLineFragmentOrigin,
       attributes,
       null
@@ -55,11 +57,15 @@ const createStringMeasurer = (textNodes: TextNodes) => (
     );
     measurements.forEach((measure) => {
       const { height: measureHeight, width: measureWidth } = measure;
-      newWidth += measureWidth;
+      // Add up all measured widths
+      newWidth += Math.ceil(measureWidth);
+      // Find the largest measured height
       if (measureHeight > newHeight) {
         newHeight = measureHeight;
       }
     });
+    // Calculate height based on number of line wraps
+    newHeight *= Math.ceil(newWidth / width);
   }
 
   return { width: newWidth, height: newHeight };

--- a/src/utils/createStringMeasurer.js
+++ b/src/utils/createStringMeasurer.js
@@ -45,9 +45,6 @@ const measureString = (textNode: TextNode, width: number) => {
 
 const createStringMeasurer = (textNodes: TextNodes) => (
   width: number
-  // widthMode,
-  // height: number,
-  // heightMode,
 ): Size => {
   let newHeight = 0;
   let newWidth = 0;

--- a/src/utils/createStringMeasurer.js
+++ b/src/utils/createStringMeasurer.js
@@ -1,11 +1,15 @@
 /* @flow */
-import { TextStyle, Size } from '../types';
+import type { TextStyle, Size, TreeNode } from '../types';
 import findFont from './findFont';
 
 // TODO(lmr): do something more sensible here
 const FLOAT_MAX = 999999;
 
-const createStringMeasurer = (string: string, style: TextStyle) => (
+const createStringMeasurer = (
+  node: TreeNode,
+  string: string,
+  style: TextStyle
+) => (
   width: number
   // widthMode,
   // height: number,

--- a/src/utils/createStringMeasurer.js
+++ b/src/utils/createStringMeasurer.js
@@ -6,10 +6,10 @@ import findFont from './findFont';
 const FLOAT_MAX = 999999;
 
 const createStringMeasurer = (string: string, style: TextStyle) => (
-  width?: number = 0
-  // widthMode: MeasureMode
+  width: number
+  // widthMode,
   // height: number,
-  // heightMode: MeasureMode
+  // heightMode,
 ): Size => {
   const font = findFont(style);
   const attributes = {

--- a/src/utils/createStringMeasurer.js
+++ b/src/utils/createStringMeasurer.js
@@ -5,47 +5,46 @@ import findFont from './findFont';
 // TODO(lmr): do something more sensible here
 const FLOAT_MAX = 999999;
 
-const createStringMeasurer = (string: string, style: TextStyle) =>
-  (
-    width: number,
-    // widthMode: MeasureMode
-    // height: number,
-    // heightMode: MeasureMode
-  ): Size => {
-    const font = findFont(style);
-    const attributes = {
-      [NSFontAttributeName]: font,
-    };
-
-    if (style.lineHeight !== undefined) {
-      // NOTE(gold): Visual explanation of NSParagraphStyle
-      // https://medium.com/@at_underscore/nsparagraphstyle-explained-visually-a8659d1fbd6f
-      const paragraphStyle = NSMutableParagraphStyle.alloc().init();
-      paragraphStyle.minimumLineHeight = style.lineHeight;
-      paragraphStyle.lineHeightMultiple = 1.0;
-      paragraphStyle.maximumLineHeight = style.lineHeight;
-      attributes[NSParagraphStyleAttributeName] = paragraphStyle;
-    }
-
-    if (style.letterSpacing !== undefined) {
-      attributes[NSKernAttributeName] = style.letterSpacing;
-    }
-
-    const rect = NSString.alloc()
-      .initWithString(string)
-      .boundingRectWithSize_options_attributes_context(
-        CGSizeMake(width, FLOAT_MAX),
-        NSStringDrawingUsesLineFragmentOrigin,
-        attributes,
-        null,
-      );
-
-    // TODO(lmr): handle other widthModes, and height/heightModes
-
-    return {
-      width: 0 + rect.size.width,
-      height: 0 + rect.size.height,
-    };
+const createStringMeasurer = (string: string, style: TextStyle) => (
+  width?: number = 0
+  // widthMode: MeasureMode
+  // height: number,
+  // heightMode: MeasureMode
+): Size => {
+  const font = findFont(style);
+  const attributes = {
+    [NSFontAttributeName]: font,
   };
+
+  if (style.lineHeight !== undefined) {
+    // NOTE(gold): Visual explanation of NSParagraphStyle
+    // https://medium.com/@at_underscore/nsparagraphstyle-explained-visually-a8659d1fbd6f
+    const paragraphStyle = NSMutableParagraphStyle.alloc().init();
+    paragraphStyle.minimumLineHeight = style.lineHeight;
+    paragraphStyle.lineHeightMultiple = 1.0;
+    paragraphStyle.maximumLineHeight = style.lineHeight;
+    attributes[NSParagraphStyleAttributeName] = paragraphStyle;
+  }
+
+  if (style.letterSpacing !== undefined) {
+    attributes[NSKernAttributeName] = style.letterSpacing;
+  }
+
+  const rect = NSString.alloc()
+    .initWithString(string)
+    .boundingRectWithSize_options_attributes_context(
+      CGSizeMake(width, FLOAT_MAX),
+      NSStringDrawingUsesLineFragmentOrigin,
+      attributes,
+      null
+    );
+
+  // TODO(lmr): handle other widthModes, and height/heightModes
+
+  return {
+    width: 0 + rect.size.width,
+    height: 0 + rect.size.height,
+  };
+};
 
 module.exports = createStringMeasurer;

--- a/src/utils/createStringMeasurer.js
+++ b/src/utils/createStringMeasurer.js
@@ -1,14 +1,11 @@
 /* @flow */
-import type { TextStyle, Size } from '../types';
+import type { TextNode, TextNodes, Size } from '../types';
 import findFont from './findFont';
 
 // TODO(lmr): do something more sensible here
 const FLOAT_MAX = 999999;
 
-const measureString = (
-  textNode: { content: string, textStyles: TextStyle },
-  width: number
-) => {
+const measureString = (textNode: TextNode, width: number) => {
   const { content, textStyles } = textNode;
   const font = findFont(textStyles);
   const attributes = {
@@ -46,9 +43,7 @@ const measureString = (
   };
 };
 
-const createStringMeasurer = (
-  textNodes: Array<{ content: string, textStyles: TextStyle }>
-) => (
+const createStringMeasurer = (textNodes: TextNodes) => (
   width: number
   // widthMode,
   // height: number,

--- a/src/utils/createStringMeasurer.js
+++ b/src/utils/createStringMeasurer.js
@@ -1,15 +1,11 @@
 /* @flow */
-import type { TextStyle, Size, TreeNode } from '../types';
+import type { TextStyle, Size } from '../types';
 import findFont from './findFont';
 
 // TODO(lmr): do something more sensible here
 const FLOAT_MAX = 999999;
 
-const createStringMeasurer = (
-  node: TreeNode,
-  string: string,
-  style: TextStyle
-) => (
+const createStringMeasurer = (string: string, style: TextStyle) => (
   width: number
   // widthMode,
   // height: number,

--- a/src/utils/findFont.js
+++ b/src/utils/findFont.js
@@ -3,6 +3,7 @@
 import { TextStyle } from '../types';
 
 import hashStyle from './hashStyle';
+import { APPLE_BROKEN_SYSTEM_FONT } from './constants';
 
 // this borrows heavily from react-native's RCTFont class
 // thanks y'all
@@ -51,7 +52,12 @@ const weightOfFont = (font: NSFont): number => {
     for (let i = 0; i < weights.length; i += 1) {
       const w = weights[i];
 
-      if (font.fontName().toLowerCase().endsWith(w)) {
+      if (
+        font
+          .fontName()
+          .toLowerCase()
+          .endsWith(w)
+      ) {
         return FONT_WEIGHTS[w];
       }
     }
@@ -62,7 +68,9 @@ const weightOfFont = (font: NSFont): number => {
 
 const fontNamesForFamilyName = (familyName: string): Array<string> => {
   const manager = NSFontManager.sharedFontManager();
-  const members = NSArray.arrayWithArray(manager.availableMembersOfFontFamily(familyName));
+  const members = NSArray.arrayWithArray(
+    manager.availableMembersOfFontFamily(familyName)
+  );
 
   const results = [];
   for (let i = 0; i < members.length; i += 1) {
@@ -93,7 +101,13 @@ const findFont = (style: TextStyle): NSFont => {
 
   let fontSize = defaultFontSize;
   let fontWeight = defaultFontWeight;
-  let familyName = defaultFontFamily;
+  // Default to Helvetica if fonts are missing
+  let familyName =
+    // Must use two equals (==) for compatibility with Cocoascript
+    // eslint-disable-next-line eqeqeq
+    defaultFontFamily == APPLE_BROKEN_SYSTEM_FONT
+      ? 'Helvetica'
+      : defaultFontFamily;
   let isItalic = false;
   let isCondensed = false;
 
@@ -134,7 +148,9 @@ const findFont = (style: TextStyle): NSFont => {
           symbolicTraits |= NSFontCondensedTrait;
         }
 
-        fontDescriptor = fontDescriptor.fontDescriptorWithSymbolicTraits(symbolicTraits);
+        fontDescriptor = fontDescriptor.fontDescriptorWithSymbolicTraits(
+          symbolicTraits
+        );
         font = NSFont.fontWithDescriptor_size(fontDescriptor, fontSize);
       }
     }
@@ -164,10 +180,15 @@ const findFont = (style: TextStyle): NSFont => {
   for (let i = 0; i < fontNames.length; i += 1) {
     const match = NSFont.fontWithName_size(fontNames[i], fontSize);
 
-    if (isItalic === isItalicFont(match) && isCondensed === isCondensedFont(match)) {
+    if (
+      isItalic === isItalicFont(match) &&
+      isCondensed === isCondensedFont(match)
+    ) {
       const testWeight = weightOfFont(match);
 
-      if (Math.abs(testWeight - fontWeight) < Math.abs(closestWeight - fontWeight)) {
+      if (
+        Math.abs(testWeight - fontWeight) < Math.abs(closestWeight - fontWeight)
+      ) {
         font = match;
 
         closestWeight = testWeight;

--- a/src/utils/isNullOrUndefined.js
+++ b/src/utils/isNullOrUndefined.js
@@ -1,0 +1,3 @@
+// @flow
+
+export default (value: any) => value === null || value === undefined;

--- a/src/utils/zIndex.js
+++ b/src/utils/zIndex.js
@@ -1,0 +1,14 @@
+// @flow
+import type { TreeNode } from '../types';
+
+// Sort z-index values highest to lowest (if `reverse` if false)
+const zIndex = (nodes: Array<TreeNode>, reverse: boolean = false) =>
+  nodes.sort((a, b) => {
+    const aIndex =
+      a.props.style && a.props.style.zIndex ? a.props.style.zIndex : 0;
+    const bIndex =
+      b.props.style && b.props.style.zIndex ? b.props.style.zIndex : 0;
+    return reverse ? bIndex - aIndex : bIndex + aIndex;
+  });
+
+export default zIndex;

--- a/src/utils/zIndex.js
+++ b/src/utils/zIndex.js
@@ -1,14 +1,19 @@
 // @flow
 import type { TreeNode } from '../types';
 
-// Sort z-index values highest to lowest (if `reverse` if false)
+// Sort z-index values highest to lowest (opposite if `reverse` is true)
 const zIndex = (nodes: Array<TreeNode>, reverse: boolean = false) =>
-  nodes.sort((a, b) => {
-    const aIndex =
-      a.props.style && a.props.style.zIndex ? a.props.style.zIndex : 0;
-    const bIndex =
-      b.props.style && b.props.style.zIndex ? b.props.style.zIndex : 0;
-    return reverse ? bIndex - aIndex : bIndex + aIndex;
-  });
+  nodes
+    .map((node: TreeNode, index: number) => ({
+      ...node,
+      oIndex: index, // Keep track of original index in array
+    }))
+    .sort((a, b) => {
+      const aIndex =
+        a.props.style && a.props.style.zIndex ? a.props.style.zIndex : 0;
+      const bIndex =
+        b.props.style && b.props.style.zIndex ? b.props.style.zIndex : 0;
+      return reverse ? aIndex - bIndex : bIndex - aIndex;
+    });
 
 export default zIndex;

--- a/src/utils/zIndex.js
+++ b/src/utils/zIndex.js
@@ -10,9 +10,13 @@ const zIndex = (nodes: Array<TreeNode>, reverse: boolean = false) =>
     }))
     .sort((a, b) => {
       const aIndex =
-        a.props.style && a.props.style.zIndex ? a.props.style.zIndex : 0;
+        a.props && a.props.style && a.props.style.zIndex
+          ? a.props.style.zIndex
+          : 0;
       const bIndex =
-        b.props.style && b.props.style.zIndex ? b.props.style.zIndex : 0;
+        b.props && b.props.style && b.props.style.zIndex
+          ? b.props.style.zIndex
+          : 0;
       return reverse ? aIndex - bIndex : bIndex - aIndex;
     });
 

--- a/yogafix.js
+++ b/yogafix.js
@@ -5,11 +5,14 @@
  * the script to compile correctly.
 */
 const fs = require('fs');
+const path = require('path');
 
 // Location of asm.js yoga-layout file
-const filePath = './node_modules/yoga-layout/build/Release/nbind.js';
+const asmPath = 'node_modules/yoga-layout/build/Release/nbind.js';
+const filePath = path.join(__dirname, asmPath);
+const workspaceFilePath = path.join(__dirname, '../../', asmPath);
 // Regex for {}("")
-const contentToReplacce = /\{\}\(""\)/g;
+const contentToReplace = /\{\}\(""\)/g;
 const replacement = '{}';
 const fileEncoding = 'utf8';
 
@@ -17,13 +20,13 @@ const SUCCESS_MESSAGE = 'Successfully fixed yoga-layout asm.js file';
 
 fs.readFile(filePath, 'utf8', (err, data) => {
   if (err) {
-    return fs.readFile(filePath, 'utf8', (err2, data2) => {
+    return fs.readFile(workspaceFilePath, 'utf8', (err2, data2) => {
       if (err2) {
         return console.error(err2); //eslint-disable-line
       }
 
-      const result = data2.replace(contentToReplacce, replacement);
-      return fs.writeFile(filePath, result, fileEncoding, (error) => {
+      const result = data2.replace(contentToReplace, replacement);
+      return fs.writeFile(workspaceFilePath, result, fileEncoding, (error) => {
         if (error) {
           return console.error(error); //eslint-disable-line
         }
@@ -33,7 +36,7 @@ fs.readFile(filePath, 'utf8', (err, data) => {
     });
   }
 
-  const result = data.replace(contentToReplacce, replacement);
+  const result = data.replace(contentToReplace, replacement);
   fs.writeFile(filePath, result, fileEncoding, (error) => {
     if (error) {
       return console.error(error); //eslint-disable-line

--- a/yogafix.js
+++ b/yogafix.js
@@ -13,9 +13,24 @@ const contentToReplacce = /\{\}\(""\)/g;
 const replacement = '{}';
 const fileEncoding = 'utf8';
 
+const SUCCESS_MESSAGE = 'Successfully fixed yoga-layout asm.js file';
+
 fs.readFile(filePath, 'utf8', (err, data) => {
   if (err) {
-    return console.error(err); //eslint-disable-line
+    return fs.readFile(filePath, 'utf8', (err2, data2) => {
+      if (err2) {
+        return console.error(err2); //eslint-disable-line
+      }
+
+      const result = data2.replace(contentToReplacce, replacement);
+      return fs.writeFile(filePath, result, fileEncoding, (error) => {
+        if (error) {
+          return console.error(error); //eslint-disable-line
+        }
+        //eslint-disable-next-line
+        return console.log(SUCCESS_MESSAGE);
+      });
+    });
   }
 
   const result = data.replace(contentToReplacce, replacement);
@@ -24,7 +39,7 @@ fs.readFile(filePath, 'utf8', (err, data) => {
       return console.error(error); //eslint-disable-line
     }
     //eslint-disable-next-line
-    return console.log("Successfully fixed yoga-layout asm.js file");
+    return console.log(SUCCESS_MESSAGE);
   });
 
   //eslint-disable-next-line

--- a/yogafix.js
+++ b/yogafix.js
@@ -1,0 +1,32 @@
+// @flow
+/*
+ * Sketch JavaScript core implementation can't handle `{}("")` and it
+ * results in a TypeError. This script removes those instances and allows
+ * the script to compile correctly.
+*/
+const fs = require('fs');
+
+// Location of asm.js yoga-layout file
+const filePath = './node_modules/yoga-layout/build/Release/nbind.js';
+// Regex for {}("")
+const contentToReplacce = /\{\}\(""\)/g;
+const replacement = '{}';
+const fileEncoding = 'utf8';
+
+fs.readFile(filePath, 'utf8', (err, data) => {
+  if (err) {
+    return console.error(err); //eslint-disable-line
+  }
+
+  const result = data.replace(contentToReplacce, replacement);
+  fs.writeFile(filePath, result, fileEncoding, (error) => {
+    if (error) {
+      return console.error(error); //eslint-disable-line
+    }
+    //eslint-disable-next-line
+    return console.log("Successfully fixed yoga-layout asm.js file");
+  });
+
+  //eslint-disable-next-line
+  return console.log("Successfully read yoga-layout asm.js file");
+});

--- a/yogafix.js
+++ b/yogafix.js
@@ -28,5 +28,5 @@ fs.readFile(filePath, 'utf8', (err, data) => {
   });
 
   //eslint-disable-next-line
-  return console.log("Successfully read yoga-layout asm.js file");
+  return console.log("Reading yoga-layout asm.js file...");
 });


### PR DESCRIPTION
# Overview

This PR overhauls nearly everything involved with layout calculation. 

It converts from the existing `css-layout` package to `yoga-layout`, preserves component tree order, adds support for `zIndex`, Implements a new nestable `<Text>` rendering engine, and provides sane default dimensions for Symbol instances. This will bring us into parity with React Native (or at least very close). 

Will now be able to use all the properties listed here: http://facebook.github.io/react-native/releases/0.48/docs/layout-props.html

> NOTE: `aspectRatio` and `direction` have been ignored since they platform specific and outside of the flexbox spec

# Z Index Support

`zIndex` style can be used to change the stacking order of your layers. This effectively allows you to put layers in front or behind each other with whatever order you desire

## Example

***Without zIndex***

```jsx
const Swatch = ({ name, hex }) => (
  <View
    name={`Swatch ${name}`}
    style={{
      height: 96,
      width: 96,
      margin: 4,
      backgroundColor: hex,
      padding: 8,
      position: 'absolute',
      top: index * 50}}
  >
    <Text
      name="Swatch Name"
      style={{ color: textColor(hex), fontWeight: 'bold' }}
    >
      {name}
    </Text>
    <Text name="Swatch Hex" style={{ color: textColor(hex) }}>
      {hex}
    </Text>
  </View>
);
```

![screen shot 2017-10-02 at 6 33 48 pm](https://user-images.githubusercontent.com/3893845/31104080-5d023544-a7a0-11e7-8423-b17dd3a7be5e.png)


***With zIndex***

```jsx
const Swatch = ({ name, hex, index }) => (
  <View
    name={`Swatch ${name}`}
    style={{
      height: 96,
      width: 96,
      margin: 4,
      backgroundColor: hex,
      padding: 8,
      position: 'absolute',
      top: index * 50,
      zIndex: index
    }}
  >
    <Text
      name="Swatch Name"
      style={{ color: textColor(hex), fontWeight: 'bold' }}
    >
      {name}
    </Text>
    <Text name="Swatch Hex" style={{ color: textColor(hex) }}>
      {hex}
    </Text>
  </View>
);
```

![screen shot 2017-10-02 at 6 33 59 pm](https://user-images.githubusercontent.com/3893845/31104081-6183c0e2-a7a0-11e7-9456-66a2004d163e.png)


Note that the stacking of Swatches has swapped.

# Fix `Missing Fonts` warning

`Helvetica` is now used as the default font if no `fontFamily` is specified on a component. This effectively removes the annoying `Missing Fonts` warning:
![screen shot 2017-10-02 at 6 04 21 pm](https://user-images.githubusercontent.com/3893845/31103374-39d5c24c-a79c-11e7-8384-22e7b3043368.png)

# New Text Layout Engine

`<Text>` components are now nestable, cascade their styles down to their children, and replicate React Native text layout [specifications](https://facebook.github.io/react-native/docs/text.html#containers).

> NOTE: Only `<Text>` components are allowed to be children of other `<Text>` components. All other components (`<View>`, `<Image>`, etc) will throw an error. This allows for the highest cross-platform compatibility.

## Example

```jsx
class BoldAndBeautiful extends Component {
  render() {
    return (
      <Text style={{fontWeight: 'bold'}}>
        I am bold{' '}
        <Text style={{color: 'red'}}>
          and red
        </Text>
      </Text>
    );
  }
}
```

<img width="402" alt="screen shot 2017-10-01 at 3 11 06 pm" src="https://user-images.githubusercontent.com/3893845/31058528-d5d30a7a-a6ba-11e7-853b-32a0c423559d.png">


# Changes
- Removed `css-layout` package
- Added `yoga-layout` package
- Tree/layout computation now uses yoga-layout to determine layout properties: width, height, top, bottom, left, and right
  - Symbol instances now use their symbol master dimensions (height/width) by default when rendered. No more 0x0 px issues if no width or height styles are provided.
  - Stacking order is fixed so rendering layers now matches component tree order
- `<Text>` components now render according to the React Native [spec](https://facebook.github.io/react-native/docs/text.html#description)
- Added support for `zIndex` style property
- Set default font to `Helvetica` in order to get rid of `Missing Fonts` message in Sketch
- Travis CI builds now use OSX as it allows for yoga to build correctly.
- Fixed example twitter image errors
- Added some more unit tests

# Breaking Changes

- `<Text>` components no longer accept [View style properties](https://github.com/vhpoet/react-native-styling-cheat-sheet#view) (`backgroundColor`, `borderWidth`, etc). This is due to now allowing Nesting of `<Text>` components and Sketch not supporting any View style properties within Text Layers. Unfortunately, it is just not feasible to to try and dynamically generate `<View>` components that map directly to text characters and locations, which is what would be required to keep this implementation. The good news is that this issue is easy to resolve by just adding a parent `<View>` component to your `<Text>` component and applying view styles to it. (Example: https://github.com/airbnb/react-sketchapp/pull/188/files#diff-d29c4465d14e21519b5b9e53e5b90cbb)
- Layer stacking has been reversed, which makes sure the order you write your components matches the order within Sketch (Fix requested here: #152). This could potentially break some layouts if you were relying on the current stacking order to place layers above/below each other. The solution would be to add `zIndex` style to correct the stacking order, or just reverse the order you wrote your child components.

# Caveats

The existing `yoga-layout` package comes with a built-in asmjs file, but it will fail to work as of `v1.6.0`. This is due to the file not being compiled with the latest emscripten `v1.37.0`. It spits out this error:  

``` 
TypeError: {} is not a function. (In '{}("")', '{}' is an instance of Object) 
``` 

  This means I had to add a hacky script called `yogaFix.js` to the project. All it does, is RegEx replace the `{}("")` code within the asm.js yoga-layout script with `{}`. This effectively fixes the problem and allows for yoga to run correctly within the Sketch JavascriptCore environment.

I'm not a huge fan of this solution, but it's simple and effective. It can also be removed once a newer asm.js version of yoga is released.

# Testing this PR

You can test this PR with the following steps:

- git clone this repo
- checkout the `feature/yoga_layout` branch
- install all packages: `npm install`
- try out any of the example projects within the `examples/` folder

# Relavant Discussions
Closes #187
Closes #52 
Closes #44 
Closes #114 
Closes #152 
Closes #15 
Closes #148 
Closes #11 

# TODOS
- [x] Use yoga to calculate sketch tree
- [x] Test that all examples are working correctly (compared to css-layout)
- [x] Correctly implement Nested Text (https://facebook.github.io/react-native/docs/text.html#description)
- [x] Calculate layout for Sketch symbols
- [x] Preserve component tree order (See #152)
- [x] Support `zIndex`
- [x] Write tests