### PR TITLE
Fix object name

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -369,8 +369,8 @@ export default (context) => {
 
   const Document = () =>
     <View>
-      <Text style={styles.Headline}>Headline text</Text>
-      <Text style={styles.Body}>Body text</Text>
+      <Text style={typeStyles.Headline}>Headline text</Text>
+      <Text style={typeStyles.Body}>Body text</Text>
     </View>
 
   render(<Document />, context.document.currentPage());


### PR DESCRIPTION
Issue - https://github.com/airbnb/react-sketchapp/issues/190

`Headline` and `Body` text styles are defined in `typeStyles` object not `styles` object.

<img width="844" alt="screenshot 2017-09-26 21 55 40" src="https://user-images.githubusercontent.com/32319933/30896441-a55a4d80-a305-11e7-8e9d-67b95ed94ac0.png">
