### PR TITLE
Reset given container instead of entire document

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -6,7 +6,7 @@ import {
 } from 'sketchapp-json-plugin';
 import buildTree from './buildTree';
 import flexToSketchJSON from './flexToSketchJSON';
-import { resetDocument, resetPage } from './resets';
+import { resetDocument, resetContainer, resetPage } from './resets';
 import { getSymbolsPage } from './symbol';
 
 import type { SketchLayer, TreeNode } from './types';
@@ -120,8 +120,8 @@ export const render = (
 ): ?SketchLayer | Array<?SketchLayer> => {
   if (appVersionSupported()) {
     try {
-      // Clear out document to prepare for re-render
-      resetDocument();
+      // Clear out container to prepare for re-render
+      resetContainer(container);
 
       // Build out sketch compatible tree representation
       const tree = buildTree(element);

--- a/src/render.js
+++ b/src/render.js
@@ -1,12 +1,9 @@
 import React from 'react';
 import type { SJLayer } from 'sketchapp-json-flow-types';
-import {
-  appVersionSupported,
-  fromSJSONDictionary,
-} from 'sketchapp-json-plugin';
+import { appVersionSupported, fromSJSONDictionary } from 'sketchapp-json-plugin';
 import buildTree from './buildTree';
 import flexToSketchJSON from './flexToSketchJSON';
-import { resetDocument, resetContainer, resetPage } from './resets';
+import { resetContainer, resetPage } from './resets';
 import { getSymbolsPage } from './symbol';
 
 import type { SketchLayer, TreeNode } from './types';
@@ -31,10 +28,7 @@ export const renderLayers = (layers, container: SketchLayer): SketchLayer => {
   return container;
 };
 
-const renderToSketch = (
-  node: TreeNode,
-  container: SketchLayer
-): SketchLayer => {
+const renderToSketch = (node: TreeNode, container: SketchLayer): SketchLayer => {
   const json = flexToSketchJSON(node);
   const layer = fromSJSONDictionary(json);
 

--- a/src/render.js
+++ b/src/render.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import type { SJLayer } from 'sketchapp-json-flow-types';
-import { appVersionSupported, fromSJSONDictionary } from 'sketchapp-json-plugin';
+import {
+  appVersionSupported,
+  fromSJSONDictionary,
+} from 'sketchapp-json-plugin';
 import buildTree from './buildTree';
 import flexToSketchJSON from './flexToSketchJSON';
-import { resetContainer, resetPage } from './resets';
+import { resetLayer } from './resets';
 import { getSymbolsPage } from './symbol';
 
 import type { SketchLayer, TreeNode } from './types';
@@ -28,7 +31,10 @@ export const renderLayers = (layers, container: SketchLayer): SketchLayer => {
   return container;
 };
 
-const renderToSketch = (node: TreeNode, container: SketchLayer): SketchLayer => {
+const renderToSketch = (
+  node: TreeNode,
+  container: SketchLayer
+): SketchLayer => {
   const json = flexToSketchJSON(node);
   const layer = fromSJSONDictionary(json);
 
@@ -96,7 +102,7 @@ const buildPages = (
 
     if (data.children && data.children.length > 0) {
       // Clear out page layers to prepare for re-render
-      resetPage(page);
+      resetLayer(page);
       data.children.forEach((child) => {
         renderToSketch(child, page);
       });
@@ -115,7 +121,7 @@ export const render = (
   if (appVersionSupported()) {
     try {
       // Clear out container to prepare for re-render
-      resetContainer(container);
+      resetLayer(container);
 
       // Build out sketch compatible tree representation
       const tree = buildTree(element);

--- a/src/render.js
+++ b/src/render.js
@@ -6,7 +6,7 @@ import {
 } from 'sketchapp-json-plugin';
 import buildTree from './buildTree';
 import flexToSketchJSON from './flexToSketchJSON';
-import { resetLayer } from './resets';
+import { resetLayer, resetDocument } from './resets';
 import { getSymbolsPage } from './symbol';
 
 import type { SketchLayer, TreeNode } from './types';
@@ -120,8 +120,12 @@ export const render = (
 ): ?SketchLayer | Array<?SketchLayer> => {
   if (appVersionSupported()) {
     try {
-      // Clear out container to prepare for re-render
-      resetLayer(container);
+      // Clear out document or layer to prepare for re-render
+      if (!container) {
+        resetDocument();
+      } else {
+        resetLayer(container);
+      }
 
       // Build out sketch compatible tree representation
       const tree = buildTree(element);

--- a/src/resets.js
+++ b/src/resets.js
@@ -1,11 +1,9 @@
 // @flow
-import type { SketchLayer } from './types';
 
-// Clear out all page layers
-export const resetPage = (page: Object) => {
-  // Can't delete the last page. Remove all layers instead
-  const layers = page.children();
-  for (let l = 0; l < layers.count(); l += 1) {
+export const resetLayer = (container: Object) => {
+  const layers = container.children();
+  // Skip last child since it is the container itself
+  for (let l = 0; l < layers.count() - 1; l += 1) {
     const layer = layers.objectAtIndex(l);
     layer.removeFromParent();
   }
@@ -24,17 +22,8 @@ export const resetDocument = () => {
       if (pages.length > 1) {
         context.document.documentData().removePageAtIndex(index);
       } else {
-        resetPage(pages[index]);
+        resetLayer(pages[index]);
       }
     }
-  }
-};
-
-export const resetContainer = (container: SketchLayer) => {
-  const layers = container.children();
-  // Skip last child since it is the container itself
-  for (let l = 0; l < layers.count() - 1; l += 1) {
-    const layer = layers.objectAtIndex(l);
-    layer.removeFromParent();
   }
 };

--- a/src/resets.js
+++ b/src/resets.js
@@ -1,4 +1,5 @@
 // @flow
+import type { SketchLayer } from './types';
 
 // Clear out all page layers
 export const resetPage = (page: Object) => {
@@ -26,5 +27,14 @@ export const resetDocument = () => {
         resetPage(pages[index]);
       }
     }
+  }
+};
+
+export const resetContainer = (container: SketchLayer) => {
+  const layers = container.children();
+  // Skip last child since it is the container itself
+  for (let l = 0; l < layers.count() - 1; l += 1) {
+    const layer = layers.objectAtIndex(l);
+    layer.removeFromParent();
   }
 };

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -8,7 +8,7 @@ import ViewStylePropTypes from './components/ViewStylePropTypes';
 import buildTree from './buildTree';
 import flexToSketchJSON from './flexToSketchJSON';
 import { renderLayers } from './render';
-import { resetPage } from './resets';
+import { resetLayer } from './resets';
 
 let id = 0;
 const nextId = () => ++id; // eslint-disable-line
@@ -93,7 +93,7 @@ const injectSymbols = () => {
   });
 
   // Clear out page layers to prepare for re-render
-  resetPage(symbolsPage);
+  resetLayer(symbolsPage);
 
   renderLayers(Object.keys(layers).map(k => layers[k]), symbolsPage);
 


### PR DESCRIPTION
Will fix https://github.com/airbnb/react-sketchapp/issues/195

Resetting the entire document assumes that the container passed to `render` is the current selected page. Whenever a group is passed as the container, render doesn't return anything since the given group will be wiped out when resetting the document.

In order to narrow down the scope of what needs to be reset I've added a function that resets the given container. 

I've left the implementation for resetting the document since I don't quite get the idea behind it. I think keeping the container immutable by resetting and rerender works.