### PR TITLE
Updates Universal Rendering Page

### DIFF
--- a/docs/guides/universal-rendering.md
+++ b/docs/guides/universal-rendering.md
@@ -26,7 +26,7 @@ import React from 'react';
 const Row = props =>
   <View>
     <Text>{ props.title }</Text>
-    <Text>{ props.description }</Text>
+    <Text>{ props.subtitle }</Text>
   </View>
 
 export default Row;


### PR DESCRIPTION
Fixes a small typo where `props.description` was being used in the `Row` module but was later being rendered as `props.subtitle` in `[platform]-entry.js`