### PR TITLE
update to skpm@1.0

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@
 **/node_modules/**
 **/flow-typed/**
 **/_book/**
+**/template/**

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,15 +6,21 @@
 #### How do I `console.log`?
 If you're using `skpm`, use `console.log` as usual.
 
-You can view the logs using `Console.app -> ~/Library/Logs -> com.bohemiancoding.sketch -> Plugin Output.log`, or in the terminal
-```bash
-tail -F ~/Library/Logs/com.bohemiancoding.sketch3/Plugin\ Output.log
-```
-
-Occasionally this file disappears — in that case, run this and then try `tail`ing again.
-```bash
-touch ~/Library/Logs/com.bohemiancoding.sketch3/Plugin\ Output.log
-```
+You have multiple options to view the logs:
+* Using the [sketch-dev-tools](https://github.com/skpm/sketch-dev-tools)
+* `Console.app -> ~/Library/Logs -> com.bohemiancoding.sketch -> Plugin Output.log`
+* in the terminal
+    ```bash
+    skpm log -f
+    ```
+* in the terminal
+    ```bash
+    tail -F ~/Library/Logs/com.bohemiancoding.sketch3/Plugin\ Output.log
+    ```
+  Occasionally this file disappears — in that case, run this and then try `tail`ing again.
+  ```bash
+  touch ~/Library/Logs/com.bohemiancoding.sketch3/Plugin\ Output.log
+  ```
 
 Outside of `skpm`, use `log` instead of `console.log`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 * [Introduction](/README.md)
 * [Examples](/docs/examples.md)
 * [Guides](/docs/guides/README.md)
+    * [Using `skpm` as a build system](/docs/guides/using-skpm.md)
     * [Data Fetching](/docs/guides/data-fetching.md)
     * [Universal Rendering](/docs/guides/universal-rendering.md)
     * [Styling](/docs/styling.md)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -2,6 +2,7 @@
 
 How to use `react-sketchapp` for fun and profit.
 
+* [Using `skpm` as a build system](using-skpm.md)
 * [Data Fetching](data-fetching.md)
 * [Universal Rendering](universal-rendering.md)
 * [Styling](styling.md)

--- a/docs/guides/data-fetching.md
+++ b/docs/guides/data-fetching.md
@@ -6,7 +6,7 @@ Pull real data from an API with `fetch` or GraphQL.
 
 [Full example](https://github.com/airbnb/react-sketchapp/tree/master/examples/foursquare-maps)
 
-`skpm` automatically provides the [Sketch `fetch` polyfill](https://github.com/mathieudutour/sketch-module-fetch-polyfill) — just use `fetch` as usual.
+`skpm` automatically provides the [Sketch `fetch` polyfill](https://github.com/skpm/sketch-polyfill-fetch) — just use `fetch` as usual.
 
 ```js
 import fetch from 'sketch-module-fetch-polyfill'

--- a/docs/guides/using-skpm.md
+++ b/docs/guides/using-skpm.md
@@ -1,0 +1,93 @@
+# Using `skpm` as a build system
+
+Sketch is allow arbitrary plugins written in [CocoaScript](http://developer.sketchapp.com/guides/cocoascript) to run. [`skpm`](https://github.com/skpm/skpm) is a utility to create, build and manage Sketch plugins. It takes care of transforming your JavaScript into CocoaScript and make sure the context it is running in is as close as possible as what you are used to when writing JavaScript.
+
+## Installation
+
+> Important: Node.js > V6.x is a minimum requirement.
+
+```bash
+npm install -g skpm
+```
+
+## Usage
+
+### Creating a new plugin
+
+```bash
+skpm create my-plugin --template=mathieudutour/skpm-sketchapp
+```
+
+> A note on templates
+>
+> The purpose of skpm templates are to provide opinionated development tooling setups so that users can get started with actual plugin code as fast as possible.
+>
+> * [`airbnb/react-sketchapp`](https://github.com/airbnb/react-sketchapp) is a simple template to get started with `react-sketchapp`
+>
+> 💁 Tip: Any Github repo with a 'template' folder can be used as a custom template: skpm create <project-name> --template=<username>/<repository>
+
+### Build the plugin
+
+Once the installation is done, you can run some commands inside the project folder:
+
+```bash
+npm run build
+```
+
+To watch for changes:
+
+```bash
+npm run watch
+```
+
+Additionally, if you wish to run the plugin every time it is built:
+
+```bash
+npm run render
+```
+
+### View the plugin's log
+
+To view the output of your `console.log`, you have a few different options:
+
+* Using the [sketch-dev-tools](https://github.com/skpm/sketch-dev-tools)
+* Open Console.app and look for the sketch logs
+* Look at the `~/Library/Logs/com.bohemiancoding.sketch3/Plugin Output.log` file
+
+Skpm provides a convenient way to do the latter:
+
+```
+skpm log
+
+  -f, -F        The `-f` option causes tail to not stop when end of file is
+                reached, but rather to wait for additional data to be appended
+                to the input.                       [boolean] [default: "false"]
+  --number, -n  Shows `number` lines of the logs.                       [number]
+```
+
+## Custom Configuration
+
+### Babel
+
+To customize Babel, you have two options:
+
+* You may create a [`.babelrc`](https://babeljs.io/docs/usage/babelrc) file in your project's root directory. Any settings you define here will overwrite matching config-keys within skpm preset. For example, if you pass a "presets" object, it will replace & reset all Babel presets that skpm defaults to.
+
+* If you'd like to modify or add to the existing Babel config, you must use a `webpack.skpm.config.js` file. Visit the [Webpack](#webpack) section for more info.
+
+### Webpack
+
+To customize webpack create `webpack.skpm.config.js` file which exports function that will change webpack's config.
+
+```js
+/**
+ * Function that mutates original webpack config.
+ * Supports asynchronous changes when promise is returned.
+ *
+ * @param {object} config - original webpack config.
+ * @param {boolean} isPluginCommand - wether the config is for a plugin command or a resource
+ **/
+module.exports = function (config, isPluginCommand) {
+  /** you can change config here **/
+}
+```

--- a/examples/basic-setup/README.md
+++ b/examples/basic-setup/README.md
@@ -12,20 +12,15 @@ Install the dependencies
 npm install
 ```
 
+Then, open Sketch and navigate to `Plugins → react-sketchapp: Basic skpm Example`
+
 Run with live reloading in Sketch, need a new sketch doc open
 ```
 npm run render
 ```
 
-Or, to install as a Sketch plugin:
-```
-npm run build
-npm run link-plugin
-```
-Then, open Sketch and navigate to `Plugins → react-sketchapp: Basic skpm Example`
-
 ## The idea behind the example
 
-[`skpm`](https://github.com/sketch-pm/skpm) is the easiest way to build `react-sketchapp` projects - this is a minimal example of it in use.
+[`skpm`](https://github.com/skpm/skpm) is the easiest way to build `react-sketchapp` projects - this is a minimal example of it in use.
 
 ![examples-basic](https://cloud.githubusercontent.com/assets/591643/24778192/1f0684ec-1ade-11e7-866b-b11bb60ac109.png)

--- a/examples/basic-setup/package.json
+++ b/examples/basic-setup/package.json
@@ -2,19 +2,21 @@
   "name": "basic-setup",
   "version": "1.0.0",
   "description": "",
-  "main": "basic-setup.sketchplugin",
-  "manifest": "src/manifest.json",
+  "skpm": {
+    "main": "basic-setup.sketchplugin",
+    "manifest": "src/manifest.json"
+  },
   "scripts": {
-    "build": "skpm build",
-    "watch": "skpm build --watch",
-    "render": "skpm build --watch --run",
-    "render:once": "skpm build --run",
-    "link-plugin": "skpm link"
+    "build": "skpm-build",
+    "watch": "skpm-build --watch",
+    "render": "skpm-build --watch --run",
+    "render:once": "skpm-build --run",
+    "postinstall": "npm run build && skpm-link"
   },
   "author": "Jon Gold <jon.gold@airbnb.com>",
   "license": "MIT",
   "devDependencies": {
-    "skpm": "^0.10.2"
+    "@skpm/builder": "^0.2.0"
   },
   "dependencies": {
     "chroma-js": "^1.2.2",

--- a/examples/colors/README.md
+++ b/examples/colors/README.md
@@ -12,17 +12,12 @@ Install the dependencies
 npm install
 ```
 
+Then, open Sketch and navigate to `Plugins → react-sketchapp: Generative Colors`
+
 Run with live reloading in Sketch, need a new sketch doc open
 ```
 npm run render
 ```
-
-Or, to install as a Sketch plugin:
-```
-npm run build
-npm run link-plugin
-```
-Then, open Sketch and navigate to `Plugins → react-sketchapp: Generative Colors`
 
 ## The idea behind the example
 

--- a/examples/colors/package.json
+++ b/examples/colors/package.json
@@ -2,14 +2,16 @@
   "name": "colors",
   "version": "1.0.0",
   "private": true,
-  "main": "colors.sketchplugin",
-  "manifest": "src/manifest.json",
+  "skpm": {
+    "main": "colors.sketchplugin",
+    "manifest": "src/manifest.json"
+  },
   "scripts": {
-    "build": "skpm build",
-    "watch": "skpm build --watch",
-    "render": "skpm build --watch --run",
-    "render:once": "skpm build --run",
-    "link-plugin": "skpm link"
+    "build": "skpm-build",
+    "watch": "skpm-build --watch",
+    "render": "skpm-build --watch --run",
+    "render:once": "skpm-build --run",
+    "postinstall": "npm run build && skpm-link"
   },
   "author": "Jon Gold <jon.gold@airbnb.com>",
   "license": "MIT",
@@ -23,6 +25,6 @@
     "webpack-shell-plugin": "^0.5.0"
   },
   "devDependencies": {
-    "skpm": "^0.10.2"
+    "@skpm/builder": "^0.2.0"
   }
 }

--- a/examples/form-validation/README.md
+++ b/examples/form-validation/README.md
@@ -12,17 +12,12 @@ Install the dependencies
 npm install
 ```
 
+Then, open Sketch and navigate to `Plugins → react-sketchapp: Form Validation`
+
 Run with live reloading in Sketch
 ```
 npm run render
 ```
-
-Or, to install as a Sketch plugin:
-```
-npm run build
-npm run link-plugin
-```
-Then, open Sketch and navigate to `Plugins → react-sketchapp: Form Validation`
 
 ## The idea behind the example
 

--- a/examples/form-validation/package.json
+++ b/examples/form-validation/package.json
@@ -2,14 +2,16 @@
   "name": "form-validation",
   "version": "1.0.0",
   "private": true,
-  "main": "form-validation.sketchplugin",
-  "manifest": "src/manifest.json",
+  "skpm": {
+    "main": "form-validation.sketchplugin",
+    "manifest": "src/manifest.json"
+  },
   "scripts": {
-    "build": "skpm build",
-    "watch": "skpm build --watch",
-    "render": "skpm build --watch --run",
-    "render:once": "skpm build --run",
-    "link-plugin": "skpm link",
+    "build": "skpm-build",
+    "watch": "skpm-build --watch",
+    "render": "skpm-build --watch --run",
+    "render:once": "skpm-build --run",
+    "postinstall": "npm run build && skpm-link",
     "web": "react run src/web.js"
   },
   "author": "Lloyd Wheeler <lloyd@lloydwheeler.co.uk>",
@@ -26,6 +28,6 @@
   "devDependencies": {
     "extract-text-webpack-plugin": "^2.1.0",
     "nwb": "^0.15.6",
-    "skpm": "^0.10.2"
+    "@skpm/builder": "^0.2.0"
   }
 }

--- a/examples/foursquare-maps/README.md
+++ b/examples/foursquare-maps/README.md
@@ -12,19 +12,13 @@ Install the dependencies
 npm install
 ```
 
+Then, open Sketch and navigate to `Plugins → react-sketchapp: Foursquare + Google Maps`
+
 ### Run it in Sketch
 Run with live reloading in Sketch
 ```
 npm run render
 ```
-
-Or, to install as a Sketch plugin:
-```
-npm run build
-npm run link-plugin
-```
-
-Then, open Sketch and navigate to `Plugins → react-sketchapp: Foursquare + Google Maps`
 
 ### Run it in your browser
 

--- a/examples/foursquare-maps/package.json
+++ b/examples/foursquare-maps/package.json
@@ -2,15 +2,17 @@
   "name": "foursquare-maps",
   "version": "1.0.0",
   "private": true,
-  "main": "foursquare-maps.sketchplugin",
-  "manifest": "src/manifest.json",
+  "skpm": {
+    "main": "foursquare-maps.sketchplugin",
+    "manifest": "src/manifest.json"
+  },
   "scripts": {
-    "build": "skpm build",
-    "watch": "skpm build --watch",
-    "render": "skpm build --watch --run",
-    "render:once": "skpm build --run",
+    "build": "skpm-build",
+    "watch": "skpm-build --watch",
+    "render": "skpm-build --watch --run",
+    "render:once": "skpm-build --run",
     "web": "react run src/web.js",
-    "link-plugin": "skpm link"
+    "postinstall": "npm run build && skpm-link"
   },
   "author": "Jon Gold <jon.gold@airbnb.com>",
   "license": "MIT",
@@ -27,6 +29,6 @@
     "react-test-renderer": "^15.4.1"
   },
   "devDependencies": {
-    "skpm": "^0.10.2"
+    "@skpm/builder": "^0.2.0"
   }
 }

--- a/examples/glamorous/README.md
+++ b/examples/glamorous/README.md
@@ -12,16 +12,10 @@ Install the dependencies
 npm install
 ```
 
+Then, open Sketch and navigate to `Plugins → react-sketchapp: glamorous`
+
 ### Run it in Sketch
 Run with live reloading in Sketch
 ```
 npm run render
 ```
-
-Or, to install as a Sketch plugin:
-```
-npm run build
-npm run link-plugin
-```
-
-Then, open Sketch and navigate to `Plugins → react-sketchapp: glamorous`

--- a/examples/glamorous/package.json
+++ b/examples/glamorous/package.json
@@ -2,19 +2,21 @@
   "name": "glamorous-example",
   "version": "1.0.0",
   "description": "",
-  "main": "glamorous.sketchplugin",
-  "manifest": "src/manifest.json",
+  "skpm": {
+    "main": "glamorous.sketchplugin",
+    "manifest": "src/manifest.json",
+  },
   "scripts": {
-    "build": "skpm build",
-    "watch": "skpm build --watch",
-    "render": "skpm build --watch --run",
-    "render:once": "skpm build --run",
-    "link-plugin": "skpm link"
+    "build": "skpm-build",
+    "watch": "skpm-build --watch",
+    "render": "skpm-build --watch --run",
+    "render:once": "skpm-build --run",
+    "postinstall": "npm run build && skpm-link"
   },
   "author": "Nitin Tulswani <tulswani19@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "skpm": "^0.10.5"
+    "@skpm/builder": "^0.2.0"
   },
   "dependencies": {
     "chroma-js": "^1.3.4",

--- a/examples/glamorous/package.json
+++ b/examples/glamorous/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "skpm": {
     "main": "glamorous.sketchplugin",
-    "manifest": "src/manifest.json",
+    "manifest": "src/manifest.json"
   },
   "scripts": {
     "build": "skpm-build",

--- a/examples/profile-cards-graphql/README.md
+++ b/examples/profile-cards-graphql/README.md
@@ -12,17 +12,12 @@ Install the dependencies
 npm install
 ```
 
+Then, open Sketch and navigate to `Plugins → react-sketchapp: Profile Cards w/ GraphQL`
+
 Run with live reloading in Sketch
 ```
 npm run render
 ```
-
-Or, to install as a Sketch plugin:
-```
-npm run build
-npm run link-plugin
-```
-Then, open Sketch and navigate to `Plugins → react-sketchapp: Profile Cards w/ GraphQL`
 
 ## The idea behind the example
 

--- a/examples/profile-cards-graphql/package.json
+++ b/examples/profile-cards-graphql/package.json
@@ -1,15 +1,17 @@
 {
   "name": "profile-cards-gql",
   "version": "1.0.0",
-  "main": "profile-cards-gql.sketchplugin",
-  "manifest": "src/manifest.json",
+  "skpm": {
+    "main": "profile-cards-gql.sketchplugin",
+    "manifest": "src/manifest.json"
+  },
   "private": true,
   "scripts": {
-    "build": "skpm build",
-    "watch": "skpm build --watch",
-    "render": "skpm build --watch --run",
-    "render:once": "skpm build --run",
-    "link-plugin": "skpm link"
+    "build": "skpm-build",
+    "watch": "skpm-build --watch",
+    "render": "skpm-build --watch --run",
+    "render:once": "skpm-build --run",
+    "postinstall": "npm run build && skpm-link"
   },
   "author": "Jon Gold <jon.gold@airbnb.com>",
   "license": "MIT",
@@ -22,6 +24,6 @@
     "react-test-renderer": "^15.4.2"
   },
   "devDependencies": {
-    "skpm": "^0.10.2"
+    "@skpm/builder": "^0.2.0"
   }
 }

--- a/examples/profile-cards-primitives/README.md
+++ b/examples/profile-cards-primitives/README.md
@@ -12,19 +12,13 @@ Install the dependencies
 npm install
 ```
 
+Then, open Sketch and navigate to `Plugins → react-sketchapp: Profile Cards w/ Primitives`
+
 ### Run it in Sketch
 Run with live reloading in Sketch
 ```
 npm run render
 ```
-
-Or, to install as a Sketch plugin:
-```
-npm run build
-npm run link-plugin
-```
-
-Then, open Sketch and navigate to `Plugins → react-sketchapp: Profile Cards w/ Primitives`
 
 ### Run it in your browser
 

--- a/examples/profile-cards-primitives/package.json
+++ b/examples/profile-cards-primitives/package.json
@@ -1,14 +1,16 @@
 {
   "name": "profile-cards-primitives",
   "private": true,
-  "main": "profile-cards-primitives.sketchplugin",
-  "manifest": "src/manifest.json",
+  "skpm": {
+    "main": "profile-cards-primitives.sketchplugin",
+    "manifest": "src/manifest.json"
+  },
   "scripts": {
-    "build": "skpm build",
-    "watch": "skpm build --watch",
-    "render": "skpm build --watch --run",
-    "render:once": "skpm build --run",
-    "link-plugin": "skpm link",
+    "build": "skpm-build",
+    "watch": "skpm-build --watch",
+    "render": "skpm-build --watch --run",
+    "render:once": "skpm-build --run",
+    "postinstall": "npm run build && skpm-link",
     "web": "react run src/web.js"
   },
   "author": "Jon Gold <jon.gold@airbnb.com>",
@@ -23,6 +25,6 @@
     "react-test-renderer": "^15.4.1"
   },
   "devDependencies": {
-    "skpm": "^0.10.2"
+    "@skpm/builder": "^0.2.0"
   }
 }

--- a/examples/profile-cards-react-with-styles/README.md
+++ b/examples/profile-cards-react-with-styles/README.md
@@ -12,18 +12,12 @@ Install the dependencies
 npm install
 ```
 
+Then, open Sketch and navigate to `Plugins → react-sketchapp: Profile Cards`
+
 Run with live reloading in Sketch
 ```
 npm run render
 ```
-
-Or, to install as a Sketch plugin:
-```
-npm run build
-npm run link-plugin
-```
-
-Then, open Sketch and navigate to `Plugins → react-sketchapp: Profile Cards`
 
 ## The idea behind the example
 

--- a/examples/profile-cards-react-with-styles/package.json
+++ b/examples/profile-cards-react-with-styles/package.json
@@ -1,14 +1,16 @@
 {
   "name": "profile-cards-react-with-styles",
   "private": true,
-  "main": "profile-cards-react-with-styles.sketchplugin",
-  "manifest": "src/manifest.json",
+  "skpm": {
+    "main": "profile-cards-react-with-styles.sketchplugin",
+    "manifest": "src/manifest.json"
+  },
   "scripts": {
-    "build": "skpm build",
-    "watch": "skpm build --watch",
-    "render": "skpm build --watch --run",
-    "render:once": "skpm build --run",
-    "link-plugin": "skpm link"
+    "build": "skpm-build",
+    "watch": "skpm-build --watch",
+    "render": "skpm-build --watch --run",
+    "render:once": "skpm-build --run",
+    "postinstall": "npm run build && skpm-link"
   },
   "author": "Jon Gold <jon.gold@airbnb.com>",
   "license": "MIT",
@@ -19,6 +21,6 @@
     "react-with-styles": "^1.4.0"
   },
   "devDependencies": {
-    "skpm": "^0.10.2"
+    "@skpm/builder": "^0.2.0"
   }
 }

--- a/examples/profile-cards/README.md
+++ b/examples/profile-cards/README.md
@@ -12,18 +12,12 @@ Install the dependencies
 npm install
 ```
 
+Then, open Sketch and navigate to `Plugins → react-sketchapp: Profile Cards`
+
 Run with live reloading in Sketch
 ```
 npm run render
 ```
-
-Or, to install as a Sketch plugin:
-```
-npm run build
-npm run link-plugin
-```
-
-Then, open Sketch and navigate to `Plugins → react-sketchapp: Profile Cards`
 
 ## The idea behind the example
 

--- a/examples/profile-cards/package.json
+++ b/examples/profile-cards/package.json
@@ -1,14 +1,16 @@
 {
   "name": "profile-cards",
   "private": true,
-  "main": "profile-cards.sketchplugin",
-  "manifest": "src/manifest.json",
+  "skpm": {
+    "main": "profile-cards.sketchplugin",
+    "manifest": "src/manifest.json"
+  },
   "scripts": {
-    "build": "skpm build",
-    "watch": "skpm build --watch",
-    "render": "skpm build --watch --run",
-    "render:once": "skpm build --run",
-    "link-plugin": "skpm link"
+    "build": "skpm-build",
+    "watch": "skpm-build --watch",
+    "render": "skpm-build --watch --run",
+    "render:once": "skpm-build --run",
+    "postinstall": "npm run build && skpm-link"
   },
   "author": "Jon Gold <jon.gold@airbnb.com>",
   "license": "MIT",
@@ -18,6 +20,6 @@
     "react-test-renderer": "^15.4.2"
   },
   "devDependencies": {
-    "skpm": "^0.10.2"
+    "@skpm/builder": "^0.2.0"
   }
 }

--- a/examples/styled-components/README.md
+++ b/examples/styled-components/README.md
@@ -12,20 +12,13 @@ Install the dependencies
 npm install
 ```
 
+Then, open Sketch and navigate to `Plugins → react-sketchapp: Styled components`
+
 ### Run it in Sketch
 Run with live reloading in Sketch
 ```
 npm run render
 ```
-
-Or, to install as a Sketch plugin:
-```
-npm run build
-npm run link-plugin
-```
-
-Then, open Sketch and navigate to `Plugins → react-sketchapp: Styled components`
-
 
 ## The idea behind the example
 

--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -2,19 +2,21 @@
   "name": "styled-components-example",
   "version": "1.0.0",
   "description": "",
-  "main": "styled-components.sketchplugin",
-  "manifest": "src/manifest.json",
+  "skpm": {
+    "main": "styled-components.sketchplugin",
+    "manifest": "src/manifest.json"
+  },
   "scripts": {
-    "build": "skpm build",
-    "watch": "skpm build --watch",
-    "render": "skpm build --watch --run",
-    "render:once": "skpm build --run",
-    "link-plugin": "skpm link"
+    "build": "skpm-build",
+    "watch": "skpm-build --watch",
+    "render": "skpm-build --watch --run",
+    "render:once": "skpm-build --run",
+    "postinstall": "npm run build && skpm-link"
   },
   "author": "Mathieu Dutour <mathieu@dutour.me>",
   "license": "MIT",
   "devDependencies": {
-    "skpm": "^0.10.2"
+    "@skpm/builder": "^0.2.0"
   },
   "dependencies": {
     "chroma-js": "^1.2.2",

--- a/examples/styleguide/README.md
+++ b/examples/styleguide/README.md
@@ -12,17 +12,12 @@ Install the dependencies
 npm install
 ```
 
+Then, open Sketch and navigate to `Plugins → react-sketchapp: Styleguide`
+
 Run with live reloading in Sketch
 ```
 npm run render
 ```
-
-Or, to install as a Sketch plugin:
-```
-npm run build
-npm run link-plugin
-```
-Then, open Sketch and navigate to `Plugins → react-sketchapp: Styleguide`
 
 ## The idea behind the example
 

--- a/examples/styleguide/package.json
+++ b/examples/styleguide/package.json
@@ -1,14 +1,16 @@
 {
   "name": "styleguide",
   "private": true,
-  "main": "styleguide.sketchplugin",
-  "manifest": "src/manifest.json",
+  "skpm": {
+    "main": "styleguide.sketchplugin",
+    "manifest": "src/manifest.json"
+  },
   "scripts": {
-    "build": "skpm build",
-    "watch": "skpm build --watch",
-    "render": "skpm build --watch --run",
-    "render:once": "skpm build --run",
-    "link-plugin": "skpm link"
+    "build": "skpm-build",
+    "watch": "skpm-build --watch",
+    "render": "skpm-build --watch --run",
+    "render:once": "skpm-build --run",
+    "postinstall": "npm run build && skpm-link"
   },
   "author": "Jon Gold <jon.gold@airbnb.com>",
   "license": "MIT",
@@ -19,6 +21,6 @@
     "react-test-renderer": "^15.4.2"
   },
   "devDependencies": {
-    "skpm": "^0.10.2"
+    "@skpm/builder": "^0.2.0"
   }
 }

--- a/examples/symbols/README.md
+++ b/examples/symbols/README.md
@@ -12,17 +12,12 @@ Install the dependencies
 npm install
 ```
 
+Then, open Sketch and navigate to `Plugins → react-sketchapp: Symbol Support`
+
 Run with live reloading in Sketch
 ```
 npm run render
 ```
-
-Or, to install as a Sketch plugin:
-```
-npm run build
-npm run link-plugin
-```
-Then, open Sketch and navigate to `Plugins → react-sketchapp: Symbol Support`
 
 ## The idea behind the example
 

--- a/examples/symbols/package.json
+++ b/examples/symbols/package.json
@@ -2,19 +2,21 @@
   "name": "symbols",
   "version": "1.0.0",
   "description": "",
-  "main": "symbols.sketchplugin",
-  "manifest": "src/manifest.json",
+  "skpm": {
+    "main": "symbols.sketchplugin",
+    "manifest": "src/manifest.json"
+  },
   "scripts": {
-    "build": "skpm build",
-    "watch": "skpm build --watch",
-    "render": "skpm build --watch --run",
-    "render:once": "skpm build --run",
-    "link-plugin": "skpm link"
+    "build": "skpm-build",
+    "watch": "skpm-build --watch",
+    "render": "skpm-build --watch --run",
+    "render:once": "skpm-build --run",
+    "postinstall": "npm run build && skpm-link"
   },
   "author": "Jon Gold <jon.gold@airbnb.com>",
   "license": "MIT",
   "devDependencies": {
-    "skpm": "^0.10.2"
+    "@skpm/builder": "^0.2.0"
   },
   "dependencies": {
     "react": "^15.4.2",

--- a/examples/timeline-airtable/README.md
+++ b/examples/timeline-airtable/README.md
@@ -12,17 +12,12 @@ Install the dependencies
 npm install
 ```
 
+Then, open Sketch and navigate to `Plugins → react-sketchapp: Timeline w/ Airtable`
+
 Run with live reloading in Sketch
 ```
 npm run render
 ```
-
-Or, to install as a Sketch plugin:
-```
-npm run build
-npm run link-plugin
-```
-Then, open Sketch and navigate to `Plugins → react-sketchapp: Timeline w/ Airtable`
 
 ## The idea behind the example
 

--- a/examples/timeline-airtable/package.json
+++ b/examples/timeline-airtable/package.json
@@ -1,14 +1,16 @@
 {
   "name": "timeline-airtable",
   "private": true,
-  "main": "timeline-airtable.sketchplugin",
-  "manifest": "src/manifest.json",
+  "skpm": {
+    "main": "timeline-airtable.sketchplugin",
+    "manifest": "src/manifest.json"
+  },
   "scripts": {
-    "build": "skpm build",
-    "watch": "skpm build --watch",
-    "render": "skpm build --watch --run",
-    "render:once": "skpm build --run",
-    "link-plugin": "skpm link"
+    "build": "skpm-build",
+    "watch": "skpm-build --watch",
+    "render": "skpm-build --watch --run",
+    "render:once": "skpm-build --run",
+    "postinstall": "npm run build && skpm-link"
   },
   "author": "David E. Chen <dchen@alumni.cmu.edu>",
   "license": "MIT",
@@ -19,6 +21,6 @@
     "react-test-renderer": "^15.4.1"
   },
   "devDependencies": {
-    "skpm": "^0.10.2"
+    "@skpm/builder": "^0.2.0"
   }
 }

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,0 +1,14 @@
+# build artifacts
+plugin.sketchplugin/Contents/Sketch
+plugin.sketchplugin/Contents/Resources/_webpack_resources
+
+# npm
+node_modules
+.npm
+npm-debug.log
+
+# mac
+.DS_Store
+
+# WebStorm
+.idea

--- a/template/README.md
+++ b/template/README.md
@@ -1,0 +1,73 @@
+# {{ name }}
+
+_This plugin was created using `skpm`. For a detailed explanation on how things work, checkout the [skpm Readme](https://github.com/skpm/skpm/blob/master/README.md)._
+
+## Usage
+
+Install the dependencies
+
+```bash
+npm install
+```
+
+Once the installation is done, you can run some commands inside the project folder:
+
+```bash
+npm run build
+```
+
+To watch for changes:
+
+```bash
+npm run watch
+```
+
+Additionally, if you wish to run the plugin every time it is built:
+
+```bash
+npm run render
+```
+
+## Custom Configuration
+
+### Babel
+
+To customize Babel, you have two options:
+
+* You may create a [`.babelrc`](https://babeljs.io/docs/usage/babelrc) file in your project's root directory. Any settings you define here will overwrite matching config-keys within skpm preset. For example, if you pass a "presets" object, it will replace & reset all Babel presets that skpm defaults to.
+
+* If you'd like to modify or add to the existing Babel config, you must use a `webpack.skpm.config.js` file. Visit the [Webpack](#webpack) section for more info.
+
+### Webpack
+
+To customize webpack create `webpack.skpm.config.js` file which exports function that will change webpack's config.
+
+```js
+/**
+ * Function that mutates original webpack config.
+ * Supports asynchronous changes when promise is returned.
+ *
+ * @param {object} config - original webpack config.
+ * @param {boolean} isPluginCommand - wether the config is for a plugin command or a resource
+ **/
+module.exports = function (config, isPluginCommand) {
+  /** you can change config here **/
+}
+```
+
+## Debugging
+
+To view the output of your `console.log`, you have a few different options:
+
+* Use the [`sketch-dev-tools`](https://github.com/skpm/sketch-dev-tools)
+* Open `Console.app` and look for the sketch logs
+* Look at the `~/Library/Logs/com.bohemiancoding.sketch3/Plugin Output.log` file
+
+Skpm provides a convenient way to do the latter:
+
+```bash
+skpm log
+```
+
+The `-f` option causes `skpm log` to not stop when the end of logs is reached, but rather to wait for additional data to be appended to the input
+

--- a/template/package.json
+++ b/template/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "foobar",
+  "version": "0.1.0",
+  "engines": {
+    "sketch": ">=3.0"
+  },
+  "skpm": {
+    "name": "foobar",
+    "manifest": "src/manifest.json",
+    "main": "plugin.sketchplugin"
+  },
+  "scripts": {
+    "build": "skpm-build",
+    "watch": "skpm-build --watch",
+    "render": "skpm-build --watch --run",
+    "render:once": "skpm-build --run",
+    "postinstall": "npm run build && skpm-link"
+  },
+  "devDependencies": {
+    "@skpm/builder": "^0.2.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.8",
+    "react": "^15.4.2",
+    "react-sketchapp": "^0.12.1",
+    "react-test-renderer": "^15.4.2"
+  }
+}

--- a/template/src/manifest.json
+++ b/template/src/manifest.json
@@ -1,0 +1,15 @@
+{
+  "compatibleVersion": 3,
+  "bundleVersion": 1,
+  "commands": [
+    {
+      "name": "my-command",
+      "identifier": "my-command-identifier",
+      "script": "./my-command.js"
+    }
+  ],
+  "menu": {
+    "title": "foobar",
+    "items": ["my-command-identifier"]
+  }
+}

--- a/template/src/my-command.js
+++ b/template/src/my-command.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { render, Artboard, Text, View } from 'react-sketchapp';
+
+const Swatch = ({ name, hex }) => (
+  <View
+    name={`Swatch ${name}`}
+    style={{
+      height: 96,
+      width: 96,
+      margin: 4,
+      backgroundColor: hex,
+      padding: 8,
+    }}
+  >
+    <Text
+      name="Swatch Name"
+      style={{ color: '#FFF', fontWeight: 'bold' }}
+    >
+      {name}
+    </Text>
+    <Text name="Swatch Hex" style={{ color: '#FFF' }}>
+      {hex}
+    </Text>
+  </View>
+);
+
+const Color = {
+  hex: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+};
+
+Swatch.propTypes = Color;
+
+const Document = ({ colors }) => (
+  <Artboard
+    name="Swatches"
+    style={{
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      width: (96 + 8) * 4,
+    }}
+  >
+    {Object.keys(colors).map(color => (
+      <Swatch name={color} hex={colors[color]} key={color} />
+    ))}
+  </Artboard>
+);
+
+Document.propTypes = {
+  colors: PropTypes.objectOf(PropTypes.string).isRequired,
+};
+
+export default () => {
+  const colorList = {
+    Haus: '#F3F4F4',
+    Night: '#333',
+    Sur: '#96DBE4',
+    'Sur Dark': '#24828F',
+    Peach: '#EFADA0',
+    'Peach Dark': '#E37059',
+    Pear: '#93DAAB',
+    'Pear Dark': '#2E854B',
+  };
+
+  render(<Document colors={colorList} />, context.document.currentPage());
+};


### PR DESCRIPTION
a few things changed with `skpm@1.0`: the build step has been split out of skpm so the install is a lot lighter.

This PR update all the examples to the new version and provide a skpm template to quickly get started with a new plugin: `skpm create my-plugin --template=airbnb/react-sketchapp` which bootstrap a new plugin using the `template` folder.

It also add a new doc to explain all of this.

Fix #199