### PR TITLE
Update dependencies examples/symbols react-sketchapp 1.0.0

### DIFF
--- a/examples/symbols/package.json
+++ b/examples/symbols/package.json
@@ -19,8 +19,8 @@
     "@skpm/builder": "^0.2.0"
   },
   "dependencies": {
-    "react": "^15.4.2",
-    "react-sketchapp": "^0.12.0",
-    "react-test-renderer": "^15.4.2"
+    "react": "^16.2.0",
+    "react-sketchapp": "^1.0.0",
+    "react-test-renderer": "^16.2.0"
   }
 }


### PR DESCRIPTION
Update dependencies for examples/symbols

```
-    "react": "^15.4.2",		        +    "react": "^16.2.0",
-    "react-sketchapp": "^0.12.0",		+    "react-sketchapp": "^1.0.0",
-    "react-test-renderer": "^15.4.2"		+    "react-test-renderer": "^16.2.0"

```