### PR TITLE
Update examples to react-sketchapp 1.0.0

### DIFF
--- a/examples/basic-setup/package.json
+++ b/examples/basic-setup/package.json
@@ -22,7 +22,7 @@
     "chroma-js": "^1.2.2",
     "prop-types": "^15.5.8",
     "react": "^15.4.2",
-    "react-sketchapp": "^0.12.1",
+    "react-sketchapp": "^1.0.0",
     "react-test-renderer": "^15.4.2"
   }
 }

--- a/examples/colors/package.json
+++ b/examples/colors/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.5.8",
     "ramda": "^0.23.0",
     "react": "^15.4.2",
-    "react-sketchapp": "^0.12.0",
+    "react-sketchapp": "^1.0.0",
     "react-test-renderer": "^15.4.1",
     "webpack-shell-plugin": "^0.5.0"
   },

--- a/examples/form-validation/package.json
+++ b/examples/form-validation/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^15.4.2",
     "react-native": "^0.42.3",
     "react-primitives": "^0.3.4",
-    "react-sketchapp": "^0.12.0",
+    "react-sketchapp": "^1.0.0",
     "react-test-renderer": "^15.4.1"
   },
   "devDependencies": {

--- a/examples/foursquare-maps/package.json
+++ b/examples/foursquare-maps/package.json
@@ -25,7 +25,7 @@
     "react-native": "^0.42.3",
     "react-primitives": "^0.3.4",
     "react-primitives-google-static-map": "^1.0.1",
-    "react-sketchapp": "^0.12.0",
+    "react-sketchapp": "^1.0.0",
     "react-test-renderer": "^15.4.1"
   },
   "devDependencies": {

--- a/examples/glamorous/package.json
+++ b/examples/glamorous/package.json
@@ -22,7 +22,7 @@
     "chroma-js": "^1.3.4",
     "glamorous-primitives": "^2.1.0",
     "react": "^15.6.1",
-    "react-sketchapp": "^0.12.1",
+    "react-sketchapp": "^1.0.0",
     "react-test-renderer": "^15.6.1"
   }
 }

--- a/examples/profile-cards-graphql/package.json
+++ b/examples/profile-cards-graphql/package.json
@@ -20,7 +20,7 @@
     "graphql-tag": "^2.4.0",
     "react": "^15.4.2",
     "react-apollo": "^1.4.2",
-    "react-sketchapp": "^0.12.0",
+    "react-sketchapp": "^1.0.0",
     "react-test-renderer": "^15.4.2"
   },
   "devDependencies": {

--- a/examples/profile-cards-primitives/package.json
+++ b/examples/profile-cards-primitives/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^15.4.2",
     "react-native": "^0.42.3",
     "react-primitives": "^0.3.4",
-    "react-sketchapp": "^0.12.0",
+    "react-sketchapp": "^1.0.0",
     "react-test-renderer": "^15.4.1"
   },
   "devDependencies": {

--- a/examples/profile-cards-react-with-styles/package.json
+++ b/examples/profile-cards-react-with-styles/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "react": "^15.4.2",
-    "react-sketchapp": "^0.12.0",
+    "react-sketchapp": "^1.0.0",
     "react-test-renderer": "^15.4.2",
     "react-with-styles": "^1.4.0"
   },

--- a/examples/profile-cards/package.json
+++ b/examples/profile-cards/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "react": "^15.4.2",
-    "react-sketchapp": "^0.12.0",
+    "react-sketchapp": "^1.0.0",
     "react-test-renderer": "^15.4.2"
   },
   "devDependencies": {

--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -23,7 +23,7 @@
     "prop-types": "^15.5.8",
     "react": "^15.4.2",
     "react-primitives": "^0.4.2",
-    "react-sketchapp": "^0.12.0",
+    "react-sketchapp": "^1.0.0",
     "react-test-renderer": "^15.4.2",
     "styled-components": "^2.1.0"
   }

--- a/examples/styleguide/package.json
+++ b/examples/styleguide/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "chroma-js": "^1.2.2",
     "react": "^15.4.2",
-    "react-sketchapp": "^0.12.0",
+    "react-sketchapp": "^1.0.0",
     "react-test-renderer": "^15.4.2"
   },
   "devDependencies": {

--- a/examples/timeline-airtable/package.json
+++ b/examples/timeline-airtable/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "prop-types": "^15.5.8",
     "react": "^15.4.2",
-    "react-sketchapp": "^0.11.0",
+    "react-sketchapp": "^1.0.0",
     "react-test-renderer": "^15.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Updating examples to react-sketchapp 1.0.0, as suggested by @mathieudutour in issue https://github.com/airbnb/react-sketchapp/issues/225

Restores functionality in Sketch 48.