### PR TITLE
fix(reactTreeToFlexTree): Fix layout for absolute layers with zIndex

### DIFF
--- a/__tests__/reactTreeToFlexTree.js
+++ b/__tests__/reactTreeToFlexTree.js
@@ -1,0 +1,153 @@
+import * as yoga from 'yoga-layout';
+import computeYogaTree from '../src/jsonUtils/computeYogaTree';
+import Context from '../src/utils/Context';
+import { reactTreeToFlexTree } from '../src/buildTree';
+
+const treeRootStub = {
+  type: 'artboard',
+  props: {
+    style: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      width: 416,
+    },
+    name: 'Swatches',
+  },
+  children: [
+    {
+      type: 'view',
+      props: {
+        name: 'Layer 1',
+        style: {
+          height: 100,
+          position: 'absolute',
+          width: 100,
+          zIndex: 1,
+        },
+      },
+    },
+    {
+      type: 'view',
+      props: {
+        name: 'Layer 2',
+        style: {
+          height: 200,
+          position: 'absolute',
+          width: 200,
+          zIndex: 2,
+        },
+      },
+    },
+    {
+      type: 'view',
+      props: {
+        name: 'Layer 3',
+        style: {
+          height: 300,
+          position: 'absolute',
+          width: 300,
+          zIndex: 3,
+        },
+      },
+    },
+  ],
+};
+
+describe('Compute Flex Tree', () => {
+  it('correctly creates flex tree', () => {
+    const yogaNode = computeYogaTree(treeRootStub, new Context());
+    yogaNode.calculateLayout(
+      yoga.UNDEFINED,
+      yoga.UNDEFINED,
+      yoga.DIRECTION_LTR
+    );
+    const tree = reactTreeToFlexTree(treeRootStub, yogaNode, new Context());
+
+    expect(tree.children).toEqual([
+      {
+        type: 'view',
+        style: {
+          height: 100,
+          position: 'absolute',
+          width: 100,
+          zIndex: 1,
+        },
+        textStyle: {},
+        layout: {
+          left: 0,
+          right: 0,
+          top: 0,
+          bottom: 0,
+          width: 100,
+          height: 100,
+        },
+        props: {
+          name: 'Layer 1',
+          style: {
+            height: 100,
+            position: 'absolute',
+            width: 100,
+            zIndex: 1,
+          },
+        },
+        children: [],
+      },
+      {
+        type: 'view',
+        style: {
+          height: 200,
+          position: 'absolute',
+          width: 200,
+          zIndex: 2,
+        },
+        textStyle: {},
+        layout: {
+          left: 0,
+          right: 0,
+          top: 0,
+          bottom: 0,
+          width: 200,
+          height: 200,
+        },
+        props: {
+          name: 'Layer 2',
+          style: {
+            height: 200,
+            position: 'absolute',
+            width: 200,
+            zIndex: 2,
+          },
+        },
+        children: [],
+      },
+      {
+        type: 'view',
+        style: {
+          height: 300,
+          position: 'absolute',
+          width: 300,
+          zIndex: 3,
+        },
+        textStyle: {},
+        layout: {
+          left: 0,
+          right: 0,
+          top: 0,
+          bottom: 0,
+          width: 300,
+          height: 300,
+        },
+        props: {
+          name: 'Layer 3',
+          style: {
+            height: 300,
+            position: 'absolute',
+            width: 300,
+            zIndex: 3,
+          },
+        },
+        children: [],
+      },
+    ]);
+  });
+});

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -9,7 +9,7 @@ import computeTextTree from './jsonUtils/computeTextTree';
 import { INHERITABLE_FONT_STYLES } from './utils/constants';
 import zIndex from './utils/zIndex';
 
-const reactTreeToFlexTree = (
+export const reactTreeToFlexTree = (
   node: TreeNode,
   yogaNode: yoga.NodeInstance,
   context: Context
@@ -62,10 +62,7 @@ const reactTreeToFlexTree = (
       // NOTE: position: absolute handles zIndexes outside of flex layout, so we
       // need to use the current child index and not it's original index (from
       // before zIndex sorting).
-      const decrementIndex =
-        children.length -
-        1 -
-        (childStyles.position === 'absolute' ? index : childComponent.oIndex);
+      const decrementIndex = children.length - 1 - index;
       const childNode = yogaNode.getChild(decrementIndex);
 
       const renderedChildComponent = reactTreeToFlexTree(


### PR DESCRIPTION
This PR is fixing a bug where the yoga layout is applied in the wrong order for layers that are positioned absolute.

- Added a fix
- In order to test the fixed bahavior reactTreeToFlexTree is now exported.