### PR TITLE
Create page only when currently on symbols page

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -73,7 +73,8 @@ const buildPages = (
 
   if (pageData.length === 0) {
     const _container = container || context.document.currentPage();
-    const page = !symbolPage ? _container : context.document.addBlankPage();
+    const page =
+      _container !== symbolPage ? _container : context.document.addBlankPage();
 
     return renderToSketch(tree, page);
   }

--- a/src/render.js
+++ b/src/render.js
@@ -74,7 +74,9 @@ const buildPages = (
   if (pageData.length === 0) {
     const _container = container || context.document.currentPage();
     const page =
-      _container !== symbolPage ? _container : context.document.addBlankPage();
+      !symbolPage || _container !== symbolPage
+        ? _container
+        : context.document.addBlankPage();
 
     return renderToSketch(tree, page);
   }


### PR DESCRIPTION
Previously, rendering would automatically create a new page if a symbols page exists at all, regardless of whether it is currently selected. This changes the behavior to use the current page when it is not the symbols page.