### PR TITLE
fix stacking order

### DIFF
--- a/__tests__/reactTreeToFlexTree.js
+++ b/__tests__/reactTreeToFlexTree.js
@@ -29,24 +29,24 @@ const treeRootStub = {
     {
       type: 'view',
       props: {
-        name: 'Layer 2',
-        style: {
-          height: 200,
-          position: 'absolute',
-          width: 200,
-          zIndex: 2,
-        },
-      },
-    },
-    {
-      type: 'view',
-      props: {
         name: 'Layer 3',
         style: {
           height: 300,
           position: 'absolute',
           width: 300,
           zIndex: 3,
+        },
+      },
+    },
+    {
+      type: 'view',
+      props: {
+        name: 'Layer 2',
+        style: {
+          height: 200,
+          position: 'absolute',
+          width: 200,
+          zIndex: 2,
         },
       },
     },
@@ -89,6 +89,7 @@ describe('Compute Flex Tree', () => {
             width: 100,
             zIndex: 1,
           },
+          textNodes: undefined,
         },
         children: [],
       },
@@ -117,6 +118,7 @@ describe('Compute Flex Tree', () => {
             width: 200,
             zIndex: 2,
           },
+          textNodes: undefined,
         },
         children: [],
       },
@@ -145,6 +147,7 @@ describe('Compute Flex Tree', () => {
             width: 300,
             zIndex: 3,
           },
+          textNodes: undefined,
         },
         children: [],
       },

--- a/__tests__/utils/zIndex.js
+++ b/__tests__/utils/zIndex.js
@@ -23,32 +23,17 @@ describe('zIndex', () => {
   it('correctly resort zIndex', () => {
     const shouldBeResorted = zIndex(fixureThatShouldBeSortedDifferently);
 
-    expect(shouldBeResorted[0].props.style.zIndex).toEqual(1);
-  });
-
-  it('correctly resort zIndex (reversed)', () => {
-    const shouldBeResorted = zIndex(fixureThatShouldBeSortedDifferently, true);
-
     expect(shouldBeResorted[0].props.style.zIndex).toEqual(0);
   });
 
   it('correctly add original index to returned objects ', () => {
     const shouldBeResorted = zIndex(fixureThatShouldBeSortedDifferently);
 
-    expect(shouldBeResorted[0].oIndex).toEqual(1);
+    expect(shouldBeResorted[0].oIndex).toEqual(0);
   });
 
   it('correctly resort zIndexes that are all the same', () => {
     const shouldNotBeResorted = zIndex(fixureThatShouldNotBeSortedDifferently);
-
-    expect(shouldNotBeResorted[0].props.style.zIndex).toEqual(0);
-  });
-
-  it('correctly resort zIndexes that are all the same (reversed)', () => {
-    const shouldNotBeResorted = zIndex(
-      fixureThatShouldNotBeSortedDifferently,
-      true
-    );
 
     expect(shouldNotBeResorted[0].props.style.zIndex).toEqual(0);
   });

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -43,30 +43,16 @@ export const reactTreeToFlexTree = (
     // Compute Text Children
     textNodes = computeTextTree(node, context);
   } else if (node.children && node.children.length > 0) {
-    // Recursion reverses the render stacking order, this corrects that
-    node.children.reverse();
+    // Recursion reverses the render stacking order
+    // but that's actually fine because Sketch renders the first on top
 
-    // Calculates zIndex order
-    const children = zIndex(node.children, true);
+    // Calculates zIndex order to match yoga
+    const children = zIndex(node.children);
 
     for (let index = 0; index < children.length; index += 1) {
       const childComponent = children[index];
-      const childStyles =
-        childComponent.props && childComponent.props.style
-          ? childComponent.props.style
-          : {};
 
-      // Since we reversed the order of children and sorted by zIndex, we need
-      // to keep track of a decrementing index using the original index of the
-      // TreeNode to get the correct layout.
-      // NOTE: position: absolute handles zIndexes outside of flex layout, so we
-      // need to use the current child index and not it's original index (from
-      // before zIndex sorting).
-      const decrementIndex =
-        children.length -
-        1 -
-        (childStyles.position === 'absolute' ? index : childComponent.oIndex);
-      const childNode = yogaNode.getChild(decrementIndex);
+      const childNode = yogaNode.getChild(index);
 
       const renderedChildComponent = reactTreeToFlexTree(
         childComponent,

--- a/src/utils/zIndex.js
+++ b/src/utils/zIndex.js
@@ -1,8 +1,8 @@
 // @flow
 import type { TreeNode } from '../types';
 
-// Sort z-index values highest to lowest (opposite if `reverse` is true)
-const zIndex = (nodes: Array<TreeNode>, reverse: boolean = false) =>
+// Sort z-index values lowest to highest
+const zIndex = (nodes: Array<TreeNode>) =>
   nodes
     .map((node: TreeNode, index: number) => ({
       ...node,
@@ -17,7 +17,7 @@ const zIndex = (nodes: Array<TreeNode>, reverse: boolean = false) =>
         b.props && b.props.style && b.props.style.zIndex
           ? b.props.style.zIndex
           : 0;
-      return reverse ? aIndex - bIndex : bIndex - aIndex;
+      return aIndex - bIndex;
     });
 
 export default zIndex;


### PR DESCRIPTION
fix #233 

It also fixes the stacking order: Sketch renders the first layer on top of the other so we need to reverse the usual children list.

You can test with the following component:
```js
const TestComponent = () => (
  <View style={{ flexDirection: 'column' }}>
    <Text>1</Text>
    <View style={{ width: 100, height: 100 }}>
      <View style={{ width: 100, height: 100, backgroundColor: 'blue', position: 'absolute' }} />
      <View style={{ width: 75, height: 75, backgroundColor: 'yellow', position: 'absolute', left: 12.5, top: 12.5 }} />
      <View style={{ width: 50, height: 50, backgroundColor: 'red', position: 'absolute', left: 25, top: 25 }} />
    </View>
    <Text>2</Text>
    <View style={{ width: 100, height: 100 }}>
      <View style={{ width: 75, height: 75, backgroundColor: 'yellow', position: 'absolute', left: 12.5, top: 12.5 }} />
      <View style={{ width: 100, height: 100, backgroundColor: 'blue', position: 'absolute', zIndex: -1 }} />
      <View style={{ width: 50, height: 50, backgroundColor: 'red', position: 'absolute', left: 25, top: 25 }} />
    </View>
    <Text>3</Text>
    <View style={{ width: 100, height: 100 }}>
      <View style={{ width: 50, height: 50, backgroundColor: 'red', position: 'absolute', left: 25, top: 25 }} />
      <View style={{ width: 75, height: 75, backgroundColor: 'yellow', position: 'absolute', left: 12.5, top: 12.5, zIndex: -1 }} />
      <View style={{ width: 100, height: 100, backgroundColor: 'blue', position: 'absolute', zIndex: -2 }} />
    </View>

  </View>
);
```

it should output this:
<img width="138" alt="screen shot 2018-02-03 at 19 37 03" src="https://user-images.githubusercontent.com/3254314/35770354-a365d286-0919-11e8-86c8-b020a821d241.png">
