### PR TITLE
Issue #216 - problematic support for local image resources

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -142,19 +142,39 @@ Wrapper for Sketch's Artboards. Requires a [`<Page>`](#page) component as a pare
 | Prop | Type | Default | Note |
 |---|---|---|---|
 | `children` | `Node` | | |
-| `source` | `ImageSource` | | |
+| `source` | `ImageSource` | | supports: jpg, png, gif, tiff |
+| `defaultSource` | `ImageSource` | | Same as ```source``` |
 | `style` | [`Style`](/docs/styling.md) | | |
-| `resizeMode` | `ResizeMode` | `contain` | |
+| `resizeMode` | `ResizeMode` | `contain` | | |
 
 ```
-type ImageSource = String | { src: String }
+type ImageSource = URI | { uri: URI, width: number, height: number }
 type ResizeMode = 'contain' | 'cover' | 'stretch' | 'center' | 'repeat' | 'none'
 ```
+```URI``` can be an http://, https:// or file:// prefixed string. If specifying a local file, the absolute path to
+the file should be used.
 
-#### Example
+Note that file:// will typically require a leading slash.
+
+Image height and width must be specified in either the ImageSource object, or
+the style object (or defaults to zero).  Style properties override ImageSource properties.
+
+#### Example (network URL)
 ```js
 <Image
   source='http://placekitten.com/400'
+  resizeMode='contain'
+  style={{
+    height: 400,
+    width: 400,
+  }}
+/>
+```
+
+#### Example (local file)
+```js
+<Image
+  source='file:///absolute/path/to/image.jpg'
   resizeMode='contain'
   style={{
     height: 400,

--- a/docs/API.md
+++ b/docs/API.md
@@ -143,7 +143,7 @@ Wrapper for Sketch's Artboards. Requires a [`<Page>`](#page) component as a pare
 |---|---|---|---|
 | `children` | `Node` | | |
 | `source` | `ImageSource` | | supports: jpg, png, gif, tiff |
-| `defaultSource` | `ImageSource` | | Same as ```source``` |
+| `defaultSource` | `ImageSource` | | Same as `source` |
 | `style` | [`Style`](/docs/styling.md) | | |
 | `resizeMode` | `ResizeMode` | `contain` | | |
 
@@ -151,6 +151,7 @@ Wrapper for Sketch's Artboards. Requires a [`<Page>`](#page) component as a pare
 type ImageSource = URI | { uri: URI, width: number, height: number }
 type ResizeMode = 'contain' | 'cover' | 'stretch' | 'center' | 'repeat' | 'none'
 ```
+
 ```URI``` can be an http://, https:// or file:// prefixed string. If specifying a local file, the absolute path to
 the file should be used.
 
@@ -159,7 +160,37 @@ Note that file:// will typically require a leading slash.
 Image height and width must be specified in either the ImageSource object, or
 the style object (or defaults to zero).  Style properties override ImageSource properties.
 
+### Important!
+
+Webpack is used to bundle the Sketch plugin output, and in the process the
+usual __dirname and __filename globals are left undefined.  As a result, its
+not possible to use these to build an absolute path to the image resource.
+
+You should create a webpack config module, which:
+
+1. Must be named `webpack.skpm.config.js`
+2. Must be located in the project root (same as `package.json`)
+
+This will ensure that `__dirname` is defined, BUT, it will be the directory
+of the project root (location on the `webpack.skpm.config.js`) and NOT the
+location of the module in which you use it.  When you reference `__dirname`
+in your code, you will need to calculate the location of your image resource
+relative to this directory.
+
+webpack.skpm.config.js:
+```js
+const webpack = require('webpack')
+
+module.exports = function (config) {
+  config.plugins = config.plugins || []
+  config.plugins.push(new webpack.DefinePlugin({
+    "__dirname": JSON.stringify(__dirname)
+  }))
+};
+```
+
 #### Example (network URL)
+
 ```js
 <Image
   source='http://placekitten.com/400'
@@ -172,6 +203,7 @@ the style object (or defaults to zero).  Style properties override ImageSource p
 ```
 
 #### Example (local file)
+
 ```js
 <Image
   source='file:///absolute/path/to/image.jpg'

--- a/examples/profile-cards/src/main.js
+++ b/examples/profile-cards/src/main.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import path from 'path';
 import { render, Text, View } from 'react-sketchapp';
 import type { User } from './types';
 import { fonts, spacing } from './designSystem';
@@ -33,8 +34,10 @@ export default () => {
         '⚛️ Makes styled-components, react-boilerplate, @KeystoneJS and CarteBlanche. ✌ Open source developer @thethinkmill. ☕ Speciality coffee geek, skier, traveller.',
       location: 'Vienna, Austria',
       url: 'mxstbr.com',
-      profile_image_url:
-        'https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg',
+      profile_image_url: `file://${path.resolve(
+        __dirname,
+        '../../docs/assets/Logo.png'
+      )}`,
     },
     {
       name: '- ̗̀Jackie ̖́-',

--- a/examples/profile-cards/webpack.skpm.config.js
+++ b/examples/profile-cards/webpack.skpm.config.js
@@ -1,0 +1,12 @@
+/* eslint-disable */
+
+const webpack = require("webpack");
+
+module.exports = function(config) {
+  config.plugins = config.plugins || [];
+  config.plugins.push(
+    new webpack.DefinePlugin({
+      __dirname: JSON.stringify(__dirname)
+    })
+  );
+};

--- a/src/jsonUtils/hacksForJSONImpl.js
+++ b/src/jsonUtils/hacksForJSONImpl.js
@@ -129,7 +129,12 @@ function makeParagraphStyle(textStyle) {
 }
 
 export const makeImageDataFromUrl = (url: string): MSImageData => {
-  let fetchedData = NSData.dataWithContentsOfURL(NSURL.URLWithString(url));
+  let fetchedData = null;
+  if (url.slice(0, 7) === 'file://') {
+    fetchedData = NSData.dataWithContentsOfFile(url.slice(7));
+  } else {
+    fetchedData = NSData.dataWithContentsOfURL(NSURL.URLWithString(url));
+  }
 
   if (fetchedData) {
     const firstByte = fetchedData


### PR DESCRIPTION
This doesn't fix the Sketch crash originally reported, that appears to be an issue with using import/require on a image resource. I believe the culprit to be the @skpm/file-loader, as its the loader that handles other assets.  It looks pretty simple in its implementation, so maybe it just causes a memory fault in Sketch after the load.  Interestingly, the `require()`'d file does end up in the plugin output.

This PR contains an enhancement to image rendering that allows an image URL to be specified in 'file://' format.  Also updated the API.md docs to illustrate correct usage.

NOTE: There is a major caveat here, in that in the plugin context, `__dirname` is set as the root directory, and not the location of the source module that you refer to it from. I have added notes to `API.md` to make this clear, and provide details on how to inject `__dirname` into the project, BUT it will be the project root, NOT the source module location.  I updated the profile-cards example to use a local file reference, pulling the logo from the docs/assets folder.  This is in a separate commit as you might decide its misleading to show it this way.  Another example might be a better approach.
