### PR TITLE
Fix Image style to allow StyleSheet ordinals and arrays

### DIFF
--- a/__tests__/components/Image.js
+++ b/__tests__/components/Image.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Image from '../../src/components/Image';
+import StyleSheet from '../../src/stylesheet';
 
 describe('<Image />', () => {
   it('renders children', () => {
@@ -161,6 +162,34 @@ describe('<Image />', () => {
             style={{ height: 400, width: 300 }}
           />
         )
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe('style', () => {
+    const styles = StyleSheet.create({
+      view: {
+        flex: 1,
+      },
+    });
+
+    it('accepts a plain object', () => {
+      const tree = renderer.create(<Image style={{ flex: 1 }} />).toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('accepts a StyleSheet ordinal', () => {
+      const tree = renderer.create(<Image style={styles.view} />).toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('accepts an array of plain objects and/or StyleSheet ordinals', () => {
+      const tree = renderer
+        .create(<Image style={[{ flexGrow: 1 }, styles.view]} />)
         .toJSON();
 
       expect(tree).toMatchSnapshot();

--- a/__tests__/components/Image.js
+++ b/__tests__/components/Image.js
@@ -4,7 +4,13 @@ import Image from '../../src/components/Image';
 
 describe('<Image />', () => {
   it('renders children', () => {
-    const tree = renderer.create(<Image source="foo"><foo /></Image>).toJSON();
+    const tree = renderer
+      .create(
+        <Image source="foo">
+          <foo />
+        </Image>
+      )
+      .toJSON();
 
     expect(tree).toMatchSnapshot();
   });
@@ -25,53 +31,51 @@ describe('<Image />', () => {
     });
   });
 
-  describe('source', () => {
-    it('prefers source over defaultSource', () => {
-      const tree = renderer.create(<Image source="foo" defaultSource="bar" />).toJSON();
-
-      expect(tree).toMatchSnapshot();
-    });
-
-    it('falls back to defaultSource if available', () => {
-      const tree = renderer.create(<Image defaultSource="foo" />).toJSON();
-
-      expect(tree).toMatchSnapshot();
-    });
-  });
-
   describe('resizeMode', () => {
     it('translates contain', () => {
-      const tree = renderer.create(<Image source="foo" resizeMode="contain" />).toJSON();
+      const tree = renderer
+        .create(<Image source="foo" resizeMode="contain" />)
+        .toJSON();
 
       expect(tree).toMatchSnapshot();
     });
 
     it('translates cover', () => {
-      const tree = renderer.create(<Image source="foo" resizeMode="cover" />).toJSON();
+      const tree = renderer
+        .create(<Image source="foo" resizeMode="cover" />)
+        .toJSON();
 
       expect(tree).toMatchSnapshot();
     });
 
     it('translates stretch', () => {
-      const tree = renderer.create(<Image source="foo" resizeMode="stretch" />).toJSON();
+      const tree = renderer
+        .create(<Image source="foo" resizeMode="stretch" />)
+        .toJSON();
 
       expect(tree).toMatchSnapshot();
     });
 
     it('translates center', () => {
-      const tree = renderer.create(<Image source="foo" resizeMode="center" />).toJSON();
+      const tree = renderer
+        .create(<Image source="foo" resizeMode="center" />)
+        .toJSON();
 
       expect(tree).toMatchSnapshot();
     });
 
     it('translates repeat', () => {
-      const tree = renderer.create(<Image source="foo" resizeMode="repeat" />).toJSON();
+      const tree = renderer
+        .create(<Image source="foo" resizeMode="repeat" />)
+        .toJSON();
 
       expect(tree).toMatchSnapshot();
     });
 
     it('translates none', () => {
-      const tree = renderer.create(<Image source="foo" resizeMode="none" />).toJSON();
+      const tree = renderer
+        .create(<Image source="foo" resizeMode="none" />)
+        .toJSON();
 
       expect(tree).toMatchSnapshot();
     });
@@ -84,7 +88,13 @@ describe('<Image />', () => {
 
     it('prefers prop to style', () => {
       const tree = renderer
-        .create(<Image source="foo" resizeMode="cover" style={{ resizeMode: 'contain' }} />)
+        .create(
+          <Image
+            source="foo"
+            resizeMode="cover"
+            style={{ resizeMode: 'contain' }}
+          />
+        )
         .toJSON();
 
       expect(tree).toMatchSnapshot();
@@ -100,21 +110,44 @@ describe('<Image />', () => {
   });
 
   describe('source', () => {
+    it('prefers source over defaultSource', () => {
+      const tree = renderer
+        .create(<Image source="foo" defaultSource="bar" />)
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('falls back to defaultSource if available', () => {
+      const tree = renderer.create(<Image defaultSource="foo" />).toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+
     it('sets height from source', () => {
-      const tree = renderer.create(<Image source={{ uri: 'foo', height: 500 }} />).toJSON();
+      const tree = renderer
+        .create(<Image source={{ uri: 'foo', height: 500 }} />)
+        .toJSON();
 
       expect(tree).toMatchSnapshot();
     });
 
     it('sets width from source', () => {
-      const tree = renderer.create(<Image source={{ uri: 'foo', width: 500 }} />).toJSON();
+      const tree = renderer
+        .create(<Image source={{ uri: 'foo', width: 500 }} />)
+        .toJSON();
 
       expect(tree).toMatchSnapshot();
     });
 
     it('favors style over source for height', () => {
       const tree = renderer
-        .create(<Image source={{ uri: 'foo', height: 500 }} style={{ height: 400, width: 300 }} />)
+        .create(
+          <Image
+            source={{ uri: 'foo', height: 500 }}
+            style={{ height: 400, width: 300 }}
+          />
+        )
         .toJSON();
 
       expect(tree).toMatchSnapshot();
@@ -122,7 +155,12 @@ describe('<Image />', () => {
 
     it('favors style over source for width', () => {
       const tree = renderer
-        .create(<Image source={{ uri: 'foo', width: 500 }} style={{ height: 400, width: 300 }} />)
+        .create(
+          <Image
+            source={{ uri: 'foo', width: 500 }}
+            style={{ height: 400, width: 300 }}
+          />
+        )
         .toJSON();
 
       expect(tree).toMatchSnapshot();

--- a/__tests__/components/__snapshots__/Image.js.snap
+++ b/__tests__/components/__snapshots__/Image.js.snap
@@ -209,3 +209,43 @@ exports[`<Image /> source sets width from source 1`] = `
     }
   } />
 `;
+
+exports[`<Image /> style accepts a StyleSheet ordinal 1`] = `
+<image
+  name="Image"
+  resizeMode="Fill"
+  resizingConstraint={undefined}
+  source={undefined}
+  style={
+    Object {
+      "flex": 1,
+    }
+  } />
+`;
+
+exports[`<Image /> style accepts a plain object 1`] = `
+<image
+  name="Image"
+  resizeMode="Fill"
+  resizingConstraint={undefined}
+  source={undefined}
+  style={
+    Object {
+      "flex": 1,
+    }
+  } />
+`;
+
+exports[`<Image /> style accepts an array of plain objects and/or StyleSheet ordinals 1`] = `
+<image
+  name="Image"
+  resizeMode="Fill"
+  resizingConstraint={undefined}
+  source={undefined}
+  style={
+    Object {
+      "flex": 1,
+      "flexGrow": 1,
+    }
+  } />
+`;

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -2,9 +2,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import StyleSheet from '../stylesheet';
-import ViewStylePropTypes from './ViewStylePropTypes';
 import ResizingConstraintPropTypes from './ResizingConstraintPropTypes';
 import ResizeModePropTypes from './ResizeModePropTypes';
+import ImageStylePropTypes from './ImageStylePropTypes';
 
 const ImageURISourcePropType = PropTypes.shape({
   uri: PropTypes.string.isRequired,
@@ -23,11 +23,6 @@ export const ImageSourcePropType = PropTypes.oneOfType([
   // PropTypes.arrayOf(ImageURISourcePropType), // TODO: handle me
   PropTypes.string,
 ]);
-
-const ImageStylePropTypes = {
-  ...ViewStylePropTypes,
-  resizeMode: ResizeModePropTypes,
-};
 
 const propTypes = {
   name: PropTypes.string,

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import StyleSheet from '../stylesheet';
 import ViewStylePropTypes from './ViewStylePropTypes';
 import ResizingConstraintPropTypes from './ResizingConstraintPropTypes';
+import ResizeModePropTypes from './ResizeModePropTypes';
 
 const ImageURISourcePropType = PropTypes.shape({
   uri: PropTypes.string.isRequired,
@@ -23,25 +24,27 @@ export const ImageSourcePropType = PropTypes.oneOfType([
   PropTypes.string,
 ]);
 
-const ResizeModePropType = PropTypes.oneOf([
-  'contain',
-  'cover',
-  'stretch',
-  'center',
-  'repeat',
-  'none',
-]);
+const ImageStylePropTypes = {
+  ...ViewStylePropTypes,
+  resizeMode: ResizeModePropTypes,
+};
 
 const propTypes = {
   name: PropTypes.string,
   children: PropTypes.any,
   defaultSource: ImageSourcePropType,
-  resizeMode: ResizeModePropType,
+  resizeMode: ResizeModePropTypes,
   source: ImageSourcePropType,
-  style: PropTypes.shape({
-    ...ViewStylePropTypes,
-    resizeMode: ResizeModePropType,
-  }),
+  style: PropTypes.oneOfType([
+    PropTypes.shape(ImageStylePropTypes),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.shape(ImageStylePropTypes),
+        PropTypes.number,
+      ])
+    ),
+    PropTypes.number,
+  ]),
   resizingConstraint: PropTypes.shape({
     ...ResizingConstraintPropTypes,
   }),

--- a/src/components/ImageStylePropTypes.js
+++ b/src/components/ImageStylePropTypes.js
@@ -1,0 +1,7 @@
+import ViewStylePropTypes from './ViewStylePropTypes';
+import ResizeModePropTypes from './ResizeModePropTypes';
+
+export default {
+  ...ViewStylePropTypes,
+  resizeMode: ResizeModePropTypes,
+};

--- a/src/components/ResizeModePropTypes.js
+++ b/src/components/ResizeModePropTypes.js
@@ -1,0 +1,10 @@
+import PropTypes from 'prop-types';
+
+export default PropTypes.oneOf([
+  'contain',
+  'cover',
+  'stretch',
+  'center',
+  'repeat',
+  'none',
+]);


### PR DESCRIPTION
As per #243, Image had PropTypes for `style` that allowed object only representation, and was therefore throwing a warning during rendering if an array of styles and/or a Stylesheet ordinal was passed.

Updated tests as appropriate.