### PR TITLE
Add Canvas component (enables rendering multiple Artboard's on existing page)

### DIFF
--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -1,0 +1,36 @@
+/* @flow */
+import React from 'react';
+import PropTypes from 'prop-types';
+import StyleSheet from '../stylesheet';
+import CanvasStylePropTypes from './CanvasStylePropTypes';
+
+const propTypes = {
+  children: PropTypes.node,
+  style: PropTypes.oneOfType([
+    PropTypes.shape({ ...CanvasStylePropTypes }),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.shape({ ...CanvasStylePropTypes }),
+        PropTypes.number,
+      ])
+    ),
+    PropTypes.number,
+  ]),
+};
+
+class Canvas extends React.Component {
+  render() {
+    const { children, style, ...otherProps } = this.props;
+    const _style = StyleSheet.flatten(style);
+
+    return (
+      <canvas style={_style} {...otherProps}>
+        {children}
+      </canvas>
+    );
+  }
+}
+
+Canvas.propTypes = propTypes;
+
+module.exports = Canvas;

--- a/src/components/CanvasStylePropTypes.js
+++ b/src/components/CanvasStylePropTypes.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import Platform from './Platform';
 import StyleSheet from './stylesheet';
 import Document from './components/Document';
 import Page from './components/Page';
+import Canvas from './components/Canvas';
 import Artboard from './components/Artboard';
 import Image from './components/Image';
 import RedBox from './components/RedBox';
@@ -19,6 +20,7 @@ module.exports = {
   StyleSheet,
   Document,
   Page,
+  Canvas,
   Artboard,
   Image,
   RedBox,

--- a/src/render.js
+++ b/src/render.js
@@ -36,6 +36,10 @@ const renderToSketch = (
   node: TreeNode,
   container: SketchLayer
 ): SketchLayer => {
+  if (node.type === 'canvas') {
+    return node.children.map(child => renderToSketch(child, container));
+  }
+
   const json = flexToSketchJSON(node);
   const layer = fromSJSONDictionary(json);
 


### PR DESCRIPTION
## Problem

There are currently two options for rendering using react-sketchapp:

1. Render the entire document using the `<Document>`, `<Page>`, and `<Artboard>` components
2. Render to an existing page (defaults to current page, but can also be explicitly passed in)

Unfortunately, rendering to an existing page has a few restrictions as pointed out in the docs:

> Artboard: Wrapper for Sketch's Artboards. Requires a `<Page>` component as a parent if you would like to use multiple of these components.

I'm not entirely sure if this restriction was put in place for a reason, but I found it to be limiting. My use case is fairly simple, I would like to render multiple `Artboard`s on a single page, without having to control the entire document.

## Solution

I would like to purpose the introduction of a new component, `Canvas`, to accomplish this. While there is no equivalent component referenced in the [Sketch API](https://developer.sketchapp.com/reference/api/), the concept is introduced and described in the [Sketch Docs](https://www.sketchapp.com/docs/the-interface/canvas/).

**Example Usage**:

```
class CustomPage extends Component {
  render () {
    return <Canvas>
      <Artboard name='Artboard 1'>
        <Text>Text1</Text>
      </Artboard>
      <Artboard name='Artboard 2'>
        <Text>Text2</Text>
      </Artboard>
    </Canvas>
  }
}

export default (context) => {
  const doc = sketch.fromNative(context.document)
  const customPage = doc.pages.find(page => page.name === 'Custom')

  render(<CustomPage />, customPage.sketchObject)
}
```

### Implementation Notes

 I chose to add this functionality inside of the `renderToSketch` method so that the `Canvas` element can be used in both contexts, when rendering to an existing page, and when rendering the entire document. I felt like allowing it to be used in both contexts would result in the least confusion. It simply introduces itself into the document Hierarchy (Document, Page, Canvas, Artboard/SymbolMaster).

I also explored the idea of adding support for multiple `Artboard`s by allowing the root element to be a `React.Fragment`. I was able to get this approach to work (and possibly this should be supported no matter what), however the `Canvas` is slightly more convenient approach as it allows the `Artboard`s to be aligned using FlexBox.

---

If this idea is of interest, I would elaborate on this PR by adding documentation, and additional tests (although it doesn't appear there are existing tests for the render code flow which I needed to alter in order to support this).