### PR TITLE
Remove `defaultProps` from `Page` component (enables auto-incrementing page name)

### DIFF
--- a/__tests__/components/Page.js
+++ b/__tests__/components/Page.js
@@ -30,12 +30,6 @@ describe('<Page />', () => {
       expect(tree).toMatchSnapshot();
     });
 
-    it('defaults to Page', () => {
-      const tree = renderer.create(<Page />).toJSON();
-
-      expect(tree).toMatchSnapshot();
-    });
-
     it('passes otherProps', () => {
       const tree = renderer
         .create(<Page propName="something" style={{}} />)

--- a/__tests__/components/__snapshots__/Page.js.snap
+++ b/__tests__/components/__snapshots__/Page.js.snap
@@ -1,9 +1,3 @@
-exports[`<Page /> name defaults to Page 1`] = `
-<page
-  name="Page 1"
-  style={undefined} />
-`;
-
 exports[`<Page /> name passes its name 1`] = `
 <page
   name="bar"
@@ -18,14 +12,14 @@ exports[`<Page /> name passes its name and avoids Symbol page conflict 1`] = `
 
 exports[`<Page /> name passes otherProps 1`] = `
 <page
-  name="Page 1"
+  name={undefined}
   propName="something"
   style={Object {}} />
 `;
 
 exports[`<Page /> renders children 1`] = `
 <page
-  name="Page 1"
+  name={undefined}
   style={undefined}>
   <foo>
     <bar />

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -20,10 +20,6 @@ const propTypes = {
 };
 
 class Page extends React.Component {
-  static defaultProps = {
-    name: 'Page 1',
-  };
-
   render() {
     const { name, children, style, ...otherProps } = this.props;
     const _name =


### PR DESCRIPTION
## Problem

The default name prop on the `Page` component provides no value. It in-fact has negative consequences. If we create multiple pages with no specified name, they will all default to `Page 1`. If instead we let the name remain undefined, Sketch will create the page using an auto-incremented name (Page 1, Page 2, Page 3, etc...)

## Solution

Remove the `defaultProps.name` definition :)

### Implementation Notes

This is a larger concern than just this particular PR, but I don't see where or how I can create tests to confirm functionality that involves Sketch's behavior (in this case, the  behavior of `document.addBlankPage`). I was able to manually test this by opening sketch and rendering multiple `Page` components without specifying the name.