### PR TITLE
Remove `nvm install-latest-npm` from `.travis.yml` to fix node6 failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ node_js:
   - '6'
   - '8'
   - '10'
-before_install:
-  - nvm install-latest-npm
 before_script:
   - npm prune
 script:


### PR DESCRIPTION
This may have been a perfect storm of events, but at some point today we started seeing failures on Travis CI when running against node 6.

Specifically [the error](https://travis-ci.org/airbnb/react-sketchapp/jobs/376605617) was occurring during the `postinstall` step of `spawn-sync` (which is a dependency of a dependency). As I began digging into debug I noticed some odd behavior:

Reviewing the last PR which passed I saw the output (slightly modified for brevity):
```
$ node --version
v6.14.2
$ npm --version
5.1.0
$ nvm --version
0.33.11
$ nvm install-latest-npm
* npm upgraded to: v5.1.0
```

And in the current failing tests I saw:
```
$ node --version
v6.14.2
$ npm --version
3.10.10
$ nvm --version
0.33.11
$ nvm install-latest-npm
* npm upgraded to: v6.0.0
```

Specifically two things stood out:
1. For some reason the passing tests had incorrectly installed npm v5.1.0 ([node 6.14.2 should install 3.10.10 by default](https://nodejs.org/en/download/releases/))
2. nvm doesn't appear to be bumping the npm version in the passing tests... this may be an oversimplification of what is actually happening behind the scenes.

The important takeaway here, is that the passing tests utilize npm v5.1.0 and the failing tests are utilizing npm v6.0.0. 

If I had more time I would attempt to track down why npm v6.0.0 is throwing an error when installing `spawn-sync` on node v6.14.1. For now however, to allow us to merge a few required PRs before releasing v2.0.0, the most straightforward approach seemed to be removing `nvm install-latest-npm` from our CI config.

cc @mathieudutour @ljharb 