### PR TITLE
Refactor SymbolInstanceRenderer `extractOverrides` method

### DIFF
--- a/src/renderers/SymbolInstanceRenderer.js
+++ b/src/renderers/SymbolInstanceRenderer.js
@@ -26,8 +26,19 @@ const overrideProps = (layer: SketchLayer): Override => ({
   name: layer.name,
 });
 
+const removeDuplicateOverrides = (overrides: Array<Override>): Array<Override> => {
+  const seen = {};
+
+  return overrides.filter(({ objectId }) => {
+    const isDuplicate = typeof seen[objectId] !== 'undefined';
+    seen[objectId] = true;
+
+    return !isDuplicate;
+  });
+};
+
 const extractOverridesHelp = (subLayer: any, output: any) => {
-  if (subLayer._class === 'text' && !output.some(r => r.objectId === subLayer.do_objectID)) {
+  if (subLayer._class === 'text') {
     output.push(overrideProps(subLayer));
     return;
   }
@@ -78,7 +89,7 @@ const extractOverridesHelp = (subLayer: any, output: any) => {
 const extractOverrides = (subLayers: any) => {
   const output = [];
   subLayers.forEach(subLayer => extractOverridesHelp(subLayer, output));
-  return output;
+  return removeDuplicateOverrides(output);
 };
 
 class SymbolInstanceRenderer extends SketchRenderer {

--- a/src/renderers/SymbolInstanceRenderer.js
+++ b/src/renderers/SymbolInstanceRenderer.js
@@ -23,6 +23,9 @@ import { makeImageDataFromUrl } from '../jsonUtils/hacksForJSONImpl';
 const findInGroup = (layer: ?SketchLayer, type: string): ?SketchLayer =>
   layer && layer.layers && layer.layers.find(l => l._class === type);
 
+const hasImageFill = (layer: SketchLayer): boolean =>
+  !!(layer.style && layer.style.fills && layer.style.fills.some(f => f.image));
+
 const extractOverridesHelp = (subLayer: any, output: any) => {
   if (subLayer._class === 'text' && !output.some(r => r.objectId === subLayer.do_objectID)) {
     output.push({
@@ -52,12 +55,7 @@ const extractOverridesHelp = (subLayer: any, output: any) => {
     // with an image fill. if it does we can do an image override on that
     // fill
     const shapeGroup = findInGroup(subLayer, 'shapeGroup');
-    if (
-      shapeGroup &&
-      shapeGroup._class === 'shapeGroup' &&
-      shapeGroup.style != null &&
-      shapeGroup.style.fills.some(f => f.image)
-    ) {
+    if (shapeGroup && hasImageFill(shapeGroup)) {
       output.push({
         type: 'image',
         objectId: shapeGroup.do_objectID,


### PR DESCRIPTION
For the most part, this PR is a little superficial. I had these stashed locally on my computer from when I was attempting to work through some bugs with symbols. I found some of the code difficult to grok / inconsistent so I slowly started making some transformations.

I think the best way to review this PR would be to review each individual commit.