### PR TITLE
Replace `mastersNameRegistry` with `symbolsRegistry`

### DIFF
--- a/src/jsonUtils/computeYogaNode.js
+++ b/src/jsonUtils/computeYogaNode.js
@@ -8,7 +8,7 @@ import pick from '../utils/pick';
 import computeTextTree from './computeTextTree';
 import { INHERITABLE_FONT_STYLES } from '../utils/constants';
 import isNullOrUndefined from '../utils/isNullOrUndefined';
-import { getSymbolMasterByName } from '../symbol';
+import { getSymbolMasterById } from '../symbol';
 
 // flatten all styles (including nested) into one object
 export const getStyles = (node: TreeNode): ViewStyle | Object => {
@@ -32,7 +32,7 @@ const computeYogaNode = (node: TreeNode, context: Context): { node: TreeNode, st
   // Setup default symbol instance dimensions
   if (node.type === 'symbolinstance') {
     const symbolProps = node.props;
-    const { frame } = getSymbolMasterByName(symbolProps.masterName);
+    const { frame } = getSymbolMasterById(symbolProps.symbolID);
     yogaNode.setWidth(frame.width);
     yogaNode.setHeight(frame.height);
   }

--- a/src/renderers/SymbolInstanceRenderer.js
+++ b/src/renderers/SymbolInstanceRenderer.js
@@ -2,14 +2,14 @@
 import SketchRenderer from './SketchRenderer';
 import { makeSymbolInstance, makeRect, makeJSONDataReference } from '../jsonUtils/models';
 import type { ViewStyle, LayoutInfo, SketchLayer, TextStyle } from '../types';
-import { getSymbolMasterByName, getSymbolMasterById } from '../symbol';
+import { getSymbolMasterById } from '../symbol';
 import { makeImageDataFromUrl } from '../jsonUtils/hacksForJSONImpl';
 
 type Override = {
   type: string,
   objectId: string,
   name: string,
-  symbolId?: string,
+  symbolID?: string,
   width?: number,
   height?: number,
 };
@@ -71,7 +71,7 @@ const extractOverridesReducer = (
   if (layer._class === 'symbolInstance') {
     return overrides.concat({
       ...overrideProps(layer),
-      symbolId: layer.symbolID,
+      symbolID: layer.symbolID,
       width: layer.frame.width,
       height: layer.frame.height,
     });
@@ -94,7 +94,7 @@ const extractOverrides = (layers: Array<SketchLayer> = []): Array<Override> => {
 
 class SymbolInstanceRenderer extends SketchRenderer {
   renderGroupLayer(layout: LayoutInfo, style: ViewStyle, textStyle: TextStyle, props: any): any {
-    const masterTree = getSymbolMasterByName(props.masterName);
+    const masterTree = getSymbolMasterById(props.symbolID);
 
     const symbolInstance = makeSymbolInstance(
       makeRect(layout.left, layout.top, layout.width, layout.height),
@@ -114,14 +114,14 @@ class SymbolInstanceRenderer extends SketchRenderer {
         // eslint-disable-next-line
         if (props.overrides.hasOwnProperty(reference.name)) {
           const overrideValue = props.overrides[reference.name];
-          if (typeof overrideValue !== 'function' || typeof overrideValue.masterName !== 'string') {
+          if (typeof overrideValue !== 'function' || typeof overrideValue.symbolID !== 'string') {
             throw new Error(
               '##FIXME## SYMBOL INSTANCE SUBSTITUTIONS MUST BE PASSED THE CONSTRUCTOR OF THE OTHER SYMBOL',
             );
           }
 
-          const originalMaster = getSymbolMasterById(reference.symbolId);
-          const replacementMaster = getSymbolMasterByName(overrideValue.masterName);
+          const originalMaster = getSymbolMasterById(reference.symbolID);
+          const replacementMaster = getSymbolMasterById(overrideValue.symbolID);
 
           if (
             originalMaster.frame.width !== replacementMaster.frame.width ||
@@ -133,7 +133,7 @@ class SymbolInstanceRenderer extends SketchRenderer {
           }
 
           const nestedOverrides = extractOverrides(
-            getSymbolMasterByName(overrideValue.masterName).layers,
+            getSymbolMasterById(overrideValue.symbolID).layers,
           ).reduce(inject, {});
 
           return {
@@ -146,7 +146,7 @@ class SymbolInstanceRenderer extends SketchRenderer {
         }
 
         const nestedOverrides = extractOverrides(
-          getSymbolMasterById(reference.symbolId).layers,
+          getSymbolMasterById(reference.symbolID).layers,
         ).reduce(inject, {});
 
         return {


### PR DESCRIPTION
This builds off of the question posed in #327. There are several reasons why this change is beneficial:

1. Optimized internals. Right now querying items by `symbolID` requires iterating over the `mastersNameRegistry` and searching for a matching ID. This compounds when you realize this iteration occurs within some recursive functions inside `SymbolInstanceRenderer`. This PR ensures all queries made within our internals are done in constant time.
2. Consistent internal API. Right now there are two methods used internally for looking up symbolMasters from the registery, `getSymbolMasterByName` and `getSymbolMasterById`. This leads to possible misuse (see 1 above) and confusion. In short, less methods in use = less developer overhead.
3. I prefer it 😂Hopefully others agree that this is a more intuitive solution.

**Additional Notes**:

A part of me wanted to simplify `getSymbolID` to:

```js
const getSymbolID = (masterName: string): string => {
  const symbolMaster = getSymbolMasterByName(masterName)
  return symbolMaster ? symbolMaster.symbolID : generateID();
};
```

but I thought I'd keep this PR more self contained and address this in a possible subsequent PR.