### PR TITLE
Update to react v16.3.2

### DIFF
--- a/examples/basic-setup-typescript/package.json
+++ b/examples/basic-setup-typescript/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "chroma-js": "^1.2.2",
     "prop-types": "^15.5.8",
-    "react": "^15.4.2",
+    "react": "^16.3.2",
     "react-sketchapp": "^2.0.0",
-    "react-test-renderer": "^15.4.2"
+    "react-test-renderer": "^16.3.2"
   }
 }

--- a/examples/basic-setup/package.json
+++ b/examples/basic-setup/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "chroma-js": "^1.2.2",
     "prop-types": "^15.5.8",
-    "react": "^15.4.2",
+    "react": "^16.3.2",
     "react-sketchapp": "^2.0.0",
-    "react-test-renderer": "^15.4.2"
+    "react-test-renderer": "^16.3.2"
   }
 }

--- a/examples/basic-svg/package.json
+++ b/examples/basic-svg/package.json
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "prop-types": "^15.5.8",
-    "react": "^15.4.2",
+    "react": "^16.3.2",
     "react-sketchapp": "^2.0.0",
-    "react-test-renderer": "^15.4.2"
+    "react-test-renderer": "^16.3.2"
   }
 }

--- a/examples/colors/package.json
+++ b/examples/colors/package.json
@@ -19,9 +19,9 @@
     "chroma-js": "^1.2.2",
     "prop-types": "^15.5.8",
     "ramda": "^0.23.0",
-    "react": "^15.4.2",
+    "react": "^16.3.2",
     "react-sketchapp": "^2.0.0",
-    "react-test-renderer": "^15.4.1",
+    "react-test-renderer": "^16.3.2",
     "webpack-shell-plugin": "^0.5.0"
   },
   "devDependencies": {

--- a/examples/form-validation/package.json
+++ b/examples/form-validation/package.json
@@ -18,12 +18,12 @@
   "license": "MIT",
   "dependencies": {
     "prop-types": "^15.5.8",
-    "react": "^15.4.2",
+    "react": "^16.3.2",
     "react-dom": "^15.4.2",
     "react-native": "^0.42.3",
     "react-primitives": "^0.3.4",
     "react-sketchapp": "^2.0.0",
-    "react-test-renderer": "^15.4.1"
+    "react-test-renderer": "^16.3.2"
   },
   "devDependencies": {
     "extract-text-webpack-plugin": "^2.1.0",

--- a/examples/foursquare-maps/package.json
+++ b/examples/foursquare-maps/package.json
@@ -20,13 +20,13 @@
     "jquery-param": "^0.2.0",
     "nwb": "^0.15.6",
     "prop-types": "^15.5.8",
-    "react": "^15.4.2",
+    "react": "^16.3.2",
     "react-dom": "^15.4.2",
     "react-native": "^0.42.3",
     "react-primitives": "^0.3.4",
     "react-primitives-google-static-map": "^1.0.1",
     "react-sketchapp": "^2.0.0",
-    "react-test-renderer": "^15.4.1"
+    "react-test-renderer": "^16.3.2"
   },
   "devDependencies": {
     "@skpm/builder": "^0.4.0"

--- a/examples/glamorous/package.json
+++ b/examples/glamorous/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "chroma-js": "^1.3.4",
     "glamorous-primitives": "^2.1.0",
-    "react": "^15.6.1",
+    "react": "^16.3.2",
     "react-sketchapp": "^2.0.0",
-    "react-test-renderer": "^15.6.1"
+    "react-test-renderer": "^16.3.2"
   }
 }

--- a/examples/profile-cards-graphql/package.json
+++ b/examples/profile-cards-graphql/package.json
@@ -21,10 +21,10 @@
     "apollo-link-http": "^1.5.3",
     "graphql": "^0.13.2",
     "graphql-tag": "^2.4.0",
-    "react": "^16.2.0",
+    "react": "^16.3.2",
     "react-apollo": "^2.1.0",
     "react-sketchapp": "^2.0.0",
-    "react-test-renderer": "^16.2.0"
+    "react-test-renderer": "^16.3.2"
   },
   "devDependencies": {
     "@skpm/builder": "^0.4.0"

--- a/examples/profile-cards-primitives/package.json
+++ b/examples/profile-cards-primitives/package.json
@@ -17,12 +17,12 @@
   "license": "MIT",
   "dependencies": {
     "nwb": "^0.15.6",
-    "react": "^15.4.2",
+    "react": "^16.3.2",
     "react-dom": "^15.4.2",
     "react-native": "^0.42.3",
     "react-primitives": "^0.3.4",
     "react-sketchapp": "^2.0.0",
-    "react-test-renderer": "^15.4.1"
+    "react-test-renderer": "^16.3.2"
   },
   "devDependencies": {
     "@skpm/builder": "^0.4.0"

--- a/examples/profile-cards-react-with-styles/package.json
+++ b/examples/profile-cards-react-with-styles/package.json
@@ -15,9 +15,9 @@
   "author": "Jon Gold <jon.gold@airbnb.com>",
   "license": "MIT",
   "dependencies": {
-    "react": "^15.4.2",
+    "react": "^16.3.2",
     "react-sketchapp": "^2.0.0",
-    "react-test-renderer": "^15.4.2",
+    "react-test-renderer": "^16.3.2",
     "react-with-styles": "^1.4.0"
   },
   "devDependencies": {

--- a/examples/profile-cards/package.json
+++ b/examples/profile-cards/package.json
@@ -15,9 +15,9 @@
   "author": "Jon Gold <jon.gold@airbnb.com>",
   "license": "MIT",
   "dependencies": {
-    "react": "^15.4.2",
+    "react": "^16.3.2",
     "react-sketchapp": "^2.0.0",
-    "react-test-renderer": "^15.4.2"
+    "react-test-renderer": "^16.3.2"
   },
   "devDependencies": {
     "@skpm/builder": "^0.4.0"

--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -21,10 +21,10 @@
   "dependencies": {
     "chroma-js": "^1.2.2",
     "prop-types": "^15.5.8",
-    "react": "^15.4.2",
+    "react": "^16.3.2",
     "react-primitives": "^0.4.2",
     "react-sketchapp": "^2.0.0",
-    "react-test-renderer": "^15.4.2",
+    "react-test-renderer": "^16.3.2",
     "styled-components": "^2.1.0"
   }
 }

--- a/examples/styleguide/package.json
+++ b/examples/styleguide/package.json
@@ -16,9 +16,9 @@
   "license": "MIT",
   "dependencies": {
     "chroma-js": "^1.2.2",
-    "react": "^15.4.2",
+    "react": "^16.3.2",
     "react-sketchapp": "^2.0.0",
-    "react-test-renderer": "^15.4.2"
+    "react-test-renderer": "^16.3.2"
   },
   "devDependencies": {
     "@skpm/builder": "^0.4.0"

--- a/examples/symbols/package.json
+++ b/examples/symbols/package.json
@@ -19,8 +19,8 @@
     "@skpm/builder": "^0.4.0"
   },
   "dependencies": {
-    "react": "^16.2.0",
+    "react": "^16.3.2",
     "react-sketchapp": "^2.0.0",
-    "react-test-renderer": "^16.2.0"
+    "react-test-renderer": "^16.3.2"
   }
 }

--- a/examples/timeline-airtable/package.json
+++ b/examples/timeline-airtable/package.json
@@ -16,9 +16,9 @@
   "license": "MIT",
   "dependencies": {
     "prop-types": "^15.5.8",
-    "react": "^15.4.2",
+    "react": "^16.3.2",
     "react-sketchapp": "^2.0.0",
-    "react-test-renderer": "^15.4.1"
+    "react-test-renderer": "^16.3.2"
   },
   "devDependencies": {
     "@skpm/builder": "^0.4.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "Mathieu Dutour <mathieu@dutour.me>",
     "Jarid Margolin <jaridmargolin@gmail.com>"
   ],
-  "pre-commit": ["flow", "lint-staged"],
+  "pre-commit": [
+    "flow",
+    "lint-staged"
+  ],
   "scripts": {
     "build:react": "babel src -d lib --ignore **/__mocks__/**",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
@@ -96,8 +99,8 @@
     "lint-staged": "^7.0.5",
     "pre-commit": "^1.2.2",
     "prettier-eslint-cli": "^4.7.1",
-    "react": "^15.4.1",
-    "react-test-renderer": "^15.4.1",
+    "react": "^16.3.2",
+    "react-test-renderer": "^16.3.2",
     "rimraf": "^2.5.4"
   }
 }

--- a/template/package.json
+++ b/template/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "prop-types": "^15.5.8",
-    "react": "^15.4.2",
+    "react": "^16.3.2",
     "react-sketchapp": "^0.12.1",
-    "react-test-renderer": "^15.4.2"
+    "react-test-renderer": "^16.3.2"
   }
 }


### PR DESCRIPTION
Ran into this while working on updating flow types. This silences some warnings displayed due to the flow recommended approach to importing types: `import * as React from 'react'`.