### PR TITLE
Remove all instances of `yoga.UNDEFINED`

### DIFF
--- a/__tests__/jsonUtils/computeYogaNode.js
+++ b/__tests__/jsonUtils/computeYogaNode.js
@@ -31,8 +31,8 @@ const createYogaNodes = (
     const treeNode = createTreeNode(style);
     const { node } = computeYogaNode(treeNode);
     node.calculateLayout(
-      containerWidth || yoga.UNDEFINED,
-      containerHeight || yoga.UNDEFINED,
+      containerWidth || undefined,
+      containerHeight || undefined,
       yoga.DIRECTION_LTR,
     );
     yogaNodes.push(node.getComputedLayout());

--- a/__tests__/jsonUtils/computeYogaTree.js
+++ b/__tests__/jsonUtils/computeYogaTree.js
@@ -40,7 +40,7 @@ computeYogaTree(treeRootStub, new Context());
 describe('Compute Yoga Tree', () => {
   it('correctly create yoga nodes into layout tree', () => {
     const yogaTree = computeYogaTree(treeRootStub, new Context());
-    yogaTree.calculateLayout(yoga.UNDEFINED, yoga.UNDEFINED, yoga.DIRECTION_LTR);
+    yogaTree.calculateLayout(undefined, undefined, yoga.DIRECTION_LTR);
     expect(yogaTree.getComputedLayout()).toEqual({
       bottom: 0,
       height: 104,

--- a/__tests__/reactTreeToFlexTree.js
+++ b/__tests__/reactTreeToFlexTree.js
@@ -56,7 +56,7 @@ const treeRootStub = {
 describe('Compute Flex Tree', () => {
   it('correctly creates flex tree', () => {
     const yogaNode = computeYogaTree(treeRootStub, new Context());
-    yogaNode.calculateLayout(yoga.UNDEFINED, yoga.UNDEFINED, yoga.DIRECTION_LTR);
+    yogaNode.calculateLayout(undefined, undefined, yoga.DIRECTION_LTR);
     const tree = reactTreeToFlexTree(treeRootStub, yogaNode, new Context());
 
     expect(tree.children).toEqual([

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -83,7 +83,7 @@ const buildTree = (element: React$Element<any>): TreeNode => {
   const renderer = TestRenderer.create(element);
   const json: TreeNode = renderer.toJSON();
   const yogaNode = computeYogaTree(json, new Context());
-  yogaNode.calculateLayout(yoga.UNDEFINED, yoga.UNDEFINED, yoga.DIRECTION_LTR);
+  yogaNode.calculateLayout(undefined, undefined, yoga.DIRECTION_LTR);
   const tree = reactTreeToFlexTree(json, yogaNode, new Context());
 
   return tree;


### PR DESCRIPTION
Ran into this while working through flow types. `yoga.UNDEFINED` doesn't exist and as a result it evaluates to... `undefined`. This silences flow and removes confusion.