### PR TITLE
run e2e tests on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: node_js
 cache:
   directories:
     - node_modules
+    - $HOME/Library/Caches/Homebrew
 notifications:
   email: false
 node_js:
@@ -11,11 +12,18 @@ node_js:
   - '8'
   - '10'
 before_install:
+  - brew update
+  - brew cask install sketch # install Sketch
+  - mkdir -p "~/Library/Application Support/com.bohemiancoding.sketch3/Plugins" # create plugins folder
+  - echo $SKETCH_LICENSE > "~/Library/Application Support/com.bohemiancoding.sketch3/.deployment" # add the Sketch license
   - nvm install-latest-npm
 before_script:
   - npm prune
 script:
   - npm run check
+  - npm run test:e2e -- --app=/Applications/Sketch.app
+after_script:
+  - rm "~/Library/App Support/com.bohemiancoding.sketch3/.deployment" # remove the Sketch license
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ cache:
 notifications:
   email: false
 node_js:
-  - '6'
-  - '8'
-  - '10'
+  - 'lts/*'
 before_install:
   - brew update
   - brew cask install sketch # install Sketch

--- a/__tests__/skpm/basic.test.js
+++ b/__tests__/skpm/basic.test.js
@@ -2,6 +2,9 @@ import * as React from 'react';
 import * as sketch from 'sketch'; // eslint-disable-line
 import { render, View, Artboard, Text } from '../../src';
 
+// depending on where those tests run, we don't get the things,
+// eg. the context might be empty or there is no selected document
+// This make sure we always get something
 function getDoc(context, document) {
   return context.document || (sketch.getSelectedDocument() || document).sketchObject;
 }

--- a/__tests__/skpm/basic.test.js
+++ b/__tests__/skpm/basic.test.js
@@ -2,6 +2,10 @@ import * as React from 'react';
 import * as sketch from 'sketch'; // eslint-disable-line
 import { render, View, Artboard, Text } from '../../src';
 
+function getDoc(context) {
+  return context.document || sketch.getSelectedDocument().sketchObject;
+}
+
 const colorList = {
   Haus: '#F3F4F4',
   Night: '#333',
@@ -14,7 +18,7 @@ const colorList = {
 };
 
 test('should render a Page with a rectangle', (context) => {
-  const nativePage = context.document.currentPage();
+  const nativePage = getDoc(context).currentPage();
   // eslint-disable-next-line
   const Swatch = ({ name, hex }) => (
     <View

--- a/__tests__/skpm/basic.test.js
+++ b/__tests__/skpm/basic.test.js
@@ -2,8 +2,8 @@ import * as React from 'react';
 import * as sketch from 'sketch'; // eslint-disable-line
 import { render, View, Artboard, Text } from '../../src';
 
-function getDoc(context) {
-  return context.document || sketch.getSelectedDocument().sketchObject;
+function getDoc(context, document) {
+  return context.document || (sketch.getSelectedDocument() || document).sketchObject;
 }
 
 const colorList = {
@@ -17,8 +17,8 @@ const colorList = {
   'Pear Dark': '#2E854B',
 };
 
-test('should render a Page with a rectangle', (context) => {
-  const nativePage = getDoc(context).currentPage();
+test('should render a Page with a rectangle', (context, document) => {
+  const nativePage = getDoc(context, document).currentPage();
   // eslint-disable-next-line
   const Swatch = ({ name, hex }) => (
     <View

--- a/src/render.js
+++ b/src/render.js
@@ -9,7 +9,7 @@ import { injectSymbols } from './symbol';
 
 import type { SketchDocumentData, SketchLayer, SketchPage, TreeNode } from './types';
 import RedBox from './components/RedBox';
-import { getDocumentFromContainer, getDocumentFromContext } from './utils/getDocument';
+import { getDocumentDataFromContainer, getDocumentDataFromContext } from './utils/getDocument';
 import isNativeDocument from './utils/isNativeDocument';
 import isNativePage from './utils/isNativePage';
 import isNativeSymbolsPage from './utils/isNativeSymbolsPage';
@@ -32,7 +32,7 @@ export const renderLayers = (layers: Array<any>, container: SketchLayer): Sketch
 };
 
 const getDefaultPage = (): SketchLayer => {
-  const doc = getDocumentFromContext(context);
+  const doc = getDocumentDataFromContext(context);
   const currentPage = doc.currentPage();
 
   return isNativeSymbolsPage(currentPage) ? doc.addBlankPage() : currentPage;
@@ -57,12 +57,12 @@ const renderPage = (tree: TreeNode, page: SketchPage): Array<SketchLayer> => {
   return children.map(child => renderContents(child, page));
 };
 
-const renderDocument = (tree: TreeNode, doc: SketchDocumentData): Array<SketchLayer> => {
-  if (!isNativeDocument(doc)) {
+const renderDocument = (tree: TreeNode, documentData: SketchDocumentData): Array<SketchLayer> => {
+  if (!isNativeDocument(documentData)) {
     throw new Error('Cannot render a Document into a child of Document');
   }
 
-  const initialPage = doc.currentPage();
+  const initialPage = documentData.currentPage();
   const shouldRenderInitialPage = !isNativeSymbolsPage(initialPage);
   const children = tree.children || [];
 
@@ -71,7 +71,7 @@ const renderDocument = (tree: TreeNode, doc: SketchDocumentData): Array<SketchLa
       throw new Error('Document children must be of type Page');
     }
 
-    const page = i === 0 && shouldRenderInitialPage ? initialPage : doc.addBlankPage();
+    const page = i === 0 && shouldRenderInitialPage ? initialPage : documentData.addBlankPage();
     return renderPage(child, page);
   });
 };
@@ -86,7 +86,7 @@ const renderTree = (tree: TreeNode, _container?: SketchLayer): SketchLayer | Arr
   }
 
   if (tree.type === 'document') {
-    const doc = _container || getDocumentFromContext(context);
+    const doc = _container || getDocumentDataFromContext(context);
 
     resetDocument(doc);
     return renderDocument(tree, doc);
@@ -114,7 +114,7 @@ export const render = (
   try {
     const tree = buildTree(element);
 
-    injectSymbols(getDocumentFromContainer(container));
+    injectSymbols(getDocumentDataFromContainer(container));
 
     return renderTree(tree, container);
   } catch (err) {

--- a/src/render.js
+++ b/src/render.js
@@ -7,7 +7,7 @@ import flexToSketchJSON from './flexToSketchJSON';
 import { resetLayer, resetDocument } from './resets';
 import { injectSymbols } from './symbol';
 
-import type { SketchDocument, SketchLayer, SketchPage, TreeNode } from './types';
+import type { SketchDocumentData, SketchLayer, SketchPage, TreeNode } from './types';
 import RedBox from './components/RedBox';
 import { getDocumentFromContainer, getDocumentFromContext } from './utils/getDocument';
 import isNativeDocument from './utils/isNativeDocument';
@@ -57,7 +57,7 @@ const renderPage = (tree: TreeNode, page: SketchPage): Array<SketchLayer> => {
   return children.map(child => renderContents(child, page));
 };
 
-const renderDocument = (tree: TreeNode, doc: SketchDocument): Array<SketchLayer> => {
+const renderDocument = (tree: TreeNode, doc: SketchDocumentData): Array<SketchLayer> => {
   if (!isNativeDocument(doc)) {
     throw new Error('Cannot render a Document into a child of Document');
   }
@@ -114,9 +114,7 @@ export const render = (
   try {
     const tree = buildTree(element);
 
-    injectSymbols(
-      container ? getDocumentFromContainer(container) : getDocumentFromContext(context),
-    );
+    injectSymbols(getDocumentFromContainer(container));
 
     return renderTree(tree, container);
   } catch (err) {

--- a/src/resets.js
+++ b/src/resets.js
@@ -17,15 +17,15 @@ export const resetLayer = (container: Object) => {
 };
 
 // Clear out all document pages and layers
-export const resetDocument = (document: SketchDocumentData) => {
+export const resetDocument = (documentData: SketchDocumentData) => {
   // Get Pages and delete them all (Except Symbols Page)
-  const pages = document.pages();
+  const pages = documentData.pages();
   for (let index = pages.length - 1; index >= 0; index -= 1) {
     const page = pages[index];
     // Don't delete symbols page
     if (!isNativeSymbolsPage(page)) {
       if (pages.length > 1) {
-        document.removePageAtIndex(index);
+        documentData.removePageAtIndex(index);
       } else {
         resetLayer(page);
       }

--- a/src/resets.js
+++ b/src/resets.js
@@ -1,5 +1,5 @@
 // @flow
-import type { SketchDocument } from './types';
+import type { SketchDocumentData } from './types';
 import isNativeDocument from './utils/isNativeDocument';
 import isNativeSymbolsPage from './utils/isNativeSymbolsPage';
 
@@ -17,7 +17,7 @@ export const resetLayer = (container: Object) => {
 };
 
 // Clear out all document pages and layers
-export const resetDocument = (document: SketchDocument) => {
+export const resetDocument = (document: SketchDocumentData) => {
   // Get Pages and delete them all (Except Symbols Page)
   const pages = document.pages();
   for (let index = pages.length - 1; index >= 0; index -= 1) {
@@ -25,7 +25,7 @@ export const resetDocument = (document: SketchDocument) => {
     // Don't delete symbols page
     if (!isNativeSymbolsPage(page)) {
       if (pages.length > 1) {
-        document.documentData().removePageAtIndex(index);
+        document.removePageAtIndex(index);
       } else {
         resetLayer(page);
       }

--- a/src/sharedStyles/TextStyles.js
+++ b/src/sharedStyles/TextStyles.js
@@ -50,7 +50,8 @@ const create = (options: Options, styles: { [key: string]: TextStyle }): StyleHa
   const { clearExistingStyles, context } = options;
 
   if (!appVersionSupported()) {
-    return context.document.showMessage('💎 Requires Sketch 43+ 💎');
+    context.document.showMessage('💎 Requires Sketch 43+ 💎');
+    return {};
   }
 
   invariant(options && options.context, 'Please provide a context');

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -10,7 +10,7 @@ import buildTree from './buildTree';
 import flexToSketchJSON from './flexToSketchJSON';
 import { renderLayers } from './render';
 import { resetLayer } from './resets';
-import { getDocumentFromContext } from './utils/getDocument';
+import { getDocumentDataFromContext } from './utils/getDocument';
 import type { SketchDocumentData } from './types';
 
 let id = 0;
@@ -33,22 +33,22 @@ const msListToArray = (pageList) => {
   return out;
 };
 
-export const getSymbolsPage = (document: SketchDocumentData) => {
-  const pages = document.pages();
+export const getSymbolsPage = (documentData: SketchDocumentData) => {
+  const pages = documentData.pages();
   const array = msListToArray(pages);
   return array.find(p => String(p.name()) === 'Symbols');
 };
 
-const getExistingSymbols = (document: SketchDocumentData) => {
+const getExistingSymbols = (documentData: SketchDocumentData) => {
   if (!hasInitialized) {
     hasInitialized = true;
 
-    let symbolsPage = getSymbolsPage(document);
+    let symbolsPage = getSymbolsPage(documentData);
     if (!symbolsPage) {
-      const currentPage = document.currentPage();
-      symbolsPage = document.addBlankPage();
+      const currentPage = documentData.currentPage();
+      symbolsPage = documentData.addBlankPage();
       symbolsPage.setName('Symbols');
-      document.setCurrentPage(currentPage);
+      documentData.setCurrentPage(currentPage);
     }
 
     existingSymbols = msListToArray(symbolsPage.layers()).map((x) => {
@@ -77,15 +77,15 @@ const getSymbolID = (masterName: string): string => {
   return symbolId;
 };
 
-export const injectSymbols = (document?: SketchDocumentData) => {
+export const injectSymbols = (documentData?: SketchDocumentData) => {
   // if hasInitialized is false then makeSymbol has not yet been called
   if (hasInitialized) {
-    if (!document) {
-      document = getDocumentFromContext(context); // eslint-disable-line
+    if (!documentData) {
+      documentData = getDocumentDataFromContext(context); // eslint-disable-line
     }
-    const currentPage = document.currentPage();
+    const currentPage = documentData.currentPage();
 
-    const symbolsPage = document.symbolsPageOrCreateIfNecessary();
+    const symbolsPage = documentData.symbolsPageOrCreateIfNecessary();
 
     let left = 0;
     Object.keys(symbolsRegistry).forEach((key) => {
@@ -103,7 +103,7 @@ export const injectSymbols = (document?: SketchDocumentData) => {
 
     renderLayers(Object.keys(layers).map(k => layers[k]), symbolsPage);
 
-    document.setCurrentPage(currentPage);
+    documentData.setCurrentPage(currentPage);
   }
 };
 
@@ -136,10 +136,10 @@ export const createSymbolInstanceClass = (symbolMaster: SJSymbolMaster): React.C
 export const makeSymbol = (
   Component: React.ComponentType<any>,
   name: string,
-  document?: any,
+  documentData?: any,
 ): React.ComponentType<any> => {
   if (!hasInitialized) {
-    getExistingSymbols(document || getDocumentFromContext(context));
+    getExistingSymbols(documentData || getDocumentDataFromContext(context));
   }
 
   const masterName = name || displayName(Component);

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -11,6 +11,7 @@ import flexToSketchJSON from './flexToSketchJSON';
 import { renderLayers } from './render';
 import { resetLayer } from './resets';
 import { getDocumentFromContext } from './utils/getDocument';
+import type { SketchDocumentData } from './types';
 
 let id = 0;
 const nextId = () => ++id; // eslint-disable-line
@@ -32,13 +33,13 @@ const msListToArray = (pageList) => {
   return out;
 };
 
-export const getSymbolsPage = (document: any) => {
+export const getSymbolsPage = (document: SketchDocumentData) => {
   const pages = document.pages();
   const array = msListToArray(pages);
   return array.find(p => String(p.name()) === 'Symbols');
 };
 
-const getExistingSymbols = (document: any) => {
+const getExistingSymbols = (document: SketchDocumentData) => {
   if (!hasInitialized) {
     hasInitialized = true;
 
@@ -74,15 +75,15 @@ const getSymbolID = (masterName: string): string => {
   return symbolId;
 };
 
-export const injectSymbols = (document: any) => {
-  if (!document) {
-    document = getDocumentFromContext(context); // eslint-disable-line
-  }
-  const currentPage = document.currentPage();
-
+export const injectSymbols = (document?: SketchDocumentData) => {
   // if hasInitialized is false then makeSymbol has not yet been called
   if (hasInitialized) {
-    const symbolsPage = document.documentData().symbolsPageOrCreateIfNecessary();
+    if (!document) {
+      document = getDocumentFromContext(context); // eslint-disable-line
+    }
+    const currentPage = document.currentPage();
+
+    const symbolsPage = document.symbolsPageOrCreateIfNecessary();
 
     let left = 0;
     Object.keys(symbolsRegistry).forEach((key) => {

--- a/src/types.js
+++ b/src/types.js
@@ -17,6 +17,7 @@ type NSString = any;
 export type SketchPage = {
   name: () => NSString,
   setName: string => void,
+  layers: () => Array<SketchLayer>,
 };
 
 export type SketchSharedStyleContainer = {
@@ -37,14 +38,16 @@ export type SketchDocumentData = {
   layerTextStyles: () => SketchSharedStyleContainer,
   layerSymbols: () => void,
   removePageAtIndex: Function,
+  addBlankPage: () => SketchPage,
+  currentPage: () => SketchPage,
+  setCurrentPage: (page: SketchPage) => void,
+  pages: () => MSArray<SketchPage>,
+  symbolsPageOrCreateIfNecessary: () => SketchPage,
 };
 
 export type SketchDocument = {
-  addBlankPage: () => SketchPage,
-  currentPage: () => SketchPage,
   documentData: () => SketchDocumentData,
-  pages: () => MSArray<SketchPage>,
-  showMessage: Function,
+  showMessage: (message: string) => void,
 };
 
 export type SketchContext = {

--- a/src/utils/getDocument.js
+++ b/src/utils/getDocument.js
@@ -1,16 +1,16 @@
 // @flow
 import type { SketchDocumentData } from '../types';
 
-export const getDocumentFromContext = (ctx: context): SketchDocumentData =>
+export const getDocumentDataFromContext = (ctx: context): SketchDocumentData =>
   (
     ctx.document ||
     (ctx.actionContext || {}).document ||
     NSDocumentController.sharedDocumentController().currentDocument()
   ).documentData();
 
-export const getDocumentFromContainer = (container?: Object): SketchDocumentData => {
+export const getDocumentDataFromContainer = (container?: Object): SketchDocumentData => {
   if (!container) {
-    return getDocumentFromContext(context);
+    return getDocumentDataFromContext(context);
   }
 
   return container.documentData();

--- a/src/utils/getDocument.js
+++ b/src/utils/getDocument.js
@@ -1,13 +1,17 @@
 // @flow
-export const getDocumentFromContext = (ctx: context) =>
-  ctx.document ||
-  ctx.actionContext.document ||
-  NSDocumentController.sharedDocumentController().currentDocument();
+import type { SketchDocumentData } from '../types';
 
-export const getDocumentFromContainer = (container: Object) => {
+export const getDocumentFromContext = (ctx: context): SketchDocumentData =>
+  (
+    ctx.document ||
+    (ctx.actionContext || {}).document ||
+    NSDocumentController.sharedDocumentController().currentDocument()
+  ).documentData();
+
+export const getDocumentFromContainer = (container?: Object): SketchDocumentData => {
   if (!container) {
     return getDocumentFromContext(context);
   }
 
-  return container.documentData().delegate();
+  return container.documentData();
 };


### PR DESCRIPTION
I needed to rework a bit some part because when running the tests, we only get an `MSDocumentData` instead of an `MSDocument`. That's actually fine because we only need that. Just need to make sure that we use the documentData instead of the document throughout the lib.
