### PR TITLE
Ensure `makeSymbol` does not change currentPage

### DIFF
--- a/src/symbol.js
+++ b/src/symbol.js
@@ -44,8 +44,10 @@ const getExistingSymbols = (document: any) => {
 
     let symbolsPage = getSymbolsPage(document);
     if (!symbolsPage) {
+      const currentPage = document.currentPage();
       symbolsPage = document.addBlankPage();
       symbolsPage.setName('Symbols');
+      document.setCurrentPage(currentPage);
     }
 
     existingSymbols = msListToArray(symbolsPage.layers()).map((x) => {


### PR DESCRIPTION
This is a quick patch to fix #351

Hopefully for a v3 release we can get around all of this hoopla by providing a more natural interface as explained in https://github.com/airbnb/react-sketchapp/issues/316#issuecomment-393725040