### PR TITLE
Use `or` PropType helper for style propTypes (from `airbnb-prop-types`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "watch": "npm run build:react -- --watch"
   },
   "dependencies": {
+    "airbnb-prop-types": "^2.10.0",
     "error-stack-parser": "^2.0.0",
     "invariant": "^2.2.2",
     "murmur2js": "^1.0.0",

--- a/src/components/Artboard.js
+++ b/src/components/Artboard.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+import { or } from 'airbnb-prop-types';
 import StyleSheet from '../stylesheet';
 import ViewStylePropTypes from './ViewStylePropTypes';
 
@@ -8,13 +9,7 @@ import ViewStylePropTypes from './ViewStylePropTypes';
 export default class Artboard extends React.Component {
   static propTypes = {
     // TODO(lmr): do some nice warning stuff like RN does
-    style: PropTypes.oneOfType([
-      PropTypes.shape({ ...ViewStylePropTypes }),
-      PropTypes.arrayOf(
-        PropTypes.oneOfType([PropTypes.shape({ ...ViewStylePropTypes }), PropTypes.number]),
-      ),
-      PropTypes.number,
-    ]),
+    style: or([PropTypes.shape(ViewStylePropTypes), PropTypes.number]),
     name: PropTypes.string,
     children: PropTypes.node,
   };

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+import { or } from 'airbnb-prop-types';
 import StyleSheet from '../stylesheet';
 import ResizingConstraintPropTypes from './ResizingConstraintPropTypes';
 import ResizeModePropTypes from './ResizeModePropTypes';
@@ -41,13 +42,7 @@ export default class Image extends React.Component {
     defaultSource: ImageSourcePropType,
     resizeMode: ResizeModePropTypes,
     source: ImageSourcePropType,
-    style: PropTypes.oneOfType([
-      PropTypes.shape(ImageStylePropTypes),
-      PropTypes.arrayOf(
-        PropTypes.oneOfType([PropTypes.shape(ImageStylePropTypes), PropTypes.number]),
-      ),
-      PropTypes.number,
-    ]),
+    style: or([PropTypes.shape(ImageStylePropTypes), PropTypes.number]),
     resizingConstraint: PropTypes.shape({
       ...ResizingConstraintPropTypes,
     }),

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+import { or } from 'airbnb-prop-types';
 import StyleSheet from '../stylesheet';
 import PageStylePropTypes from './PageStylePropTypes';
 
@@ -9,13 +10,7 @@ export default class Page extends React.Component {
   static propTypes = {
     name: PropTypes.string,
     children: PropTypes.node,
-    style: PropTypes.oneOfType([
-      PropTypes.shape({ ...PageStylePropTypes }),
-      PropTypes.arrayOf(
-        PropTypes.oneOfType([PropTypes.shape({ ...PageStylePropTypes }), PropTypes.number]),
-      ),
-      PropTypes.number,
-    ]),
+    style: or([PropTypes.shape(PageStylePropTypes), PropTypes.number]),
   };
 
   render() {

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+import { or } from 'airbnb-prop-types';
 import StyleSheet from '../stylesheet';
 import TextStylePropTypes from './TextStylePropTypes';
 import ViewStylePropTypes from './ViewStylePropTypes';
@@ -16,17 +17,10 @@ import ResizingConstraintPropTypes from './ResizingConstraintPropTypes';
 export default class Text extends React.Component {
   static propTypes = {
     // TODO(lmr): do some nice warning stuff like RN does
-    style: PropTypes.oneOfType([
+    style: or([
       PropTypes.shape({ ...ViewStylePropTypes, ...TextStylePropTypes }),
-      PropTypes.arrayOf(
-        PropTypes.oneOfType([
-          PropTypes.shape({ ...ViewStylePropTypes, ...TextStylePropTypes }),
-          PropTypes.number,
-        ]),
-      ),
       PropTypes.number,
     ]),
-
     name: PropTypes.string,
     resizingConstraint: PropTypes.shape({
       ...ResizingConstraintPropTypes,

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+import { or } from 'airbnb-prop-types';
 import StyleSheet from '../stylesheet';
 import ViewStylePropTypes from './ViewStylePropTypes';
 import ResizingConstraintPropTypes from './ResizingConstraintPropTypes';
@@ -9,13 +10,7 @@ import ResizingConstraintPropTypes from './ResizingConstraintPropTypes';
 export default class View extends React.Component {
   static propTypes = {
     // TODO(lmr): do some nice warning stuff like RN does
-    style: PropTypes.oneOfType([
-      PropTypes.shape({ ...ViewStylePropTypes }),
-      PropTypes.arrayOf(
-        PropTypes.oneOfType([PropTypes.shape({ ...ViewStylePropTypes }), PropTypes.number]),
-      ),
-      PropTypes.number,
-    ]),
+    style: or([PropTypes.shape(ViewStylePropTypes), PropTypes.number]),
     name: PropTypes.string,
     resizingConstraint: PropTypes.shape({
       ...ResizingConstraintPropTypes,


### PR DESCRIPTION
As I was going to implement `Page.Container`, I noticed I noticed that the style PropType definitions were all pretty verbose.

As I was looking for a better solution, I stumbled on this lovely little library built by the kind folks (@ljharb) at a company called "airbnb".