### PR TITLE
Feature/shadows

### DIFF
--- a/__tests__/jest/components/__snapshots__/RedBox.js.snap
+++ b/__tests__/jest/components/__snapshots__/RedBox.js.snap
@@ -4,6 +4,7 @@ exports[`<RedBox /> renders simple errors 1`] = `
 <view
   name="RedBox"
   resizingConstraint={undefined}
+  shadows={undefined}
   style={
     Object {
       "backgroundColor": "rgb(204, 0, 0)",
@@ -32,6 +33,7 @@ exports[`<RedBox /> renders simple errors 1`] = `
   <view
     name="Frames"
     resizingConstraint={undefined}
+    shadows={undefined}
     style={
       Object {
         "color": "white",
@@ -176,6 +178,7 @@ exports[`<RedBox /> renders string errors 1`] = `
 <view
   name="RedBox"
   resizingConstraint={undefined}
+  shadows={undefined}
   style={
     Object {
       "backgroundColor": "rgb(204, 0, 0)",

--- a/__tests__/jest/components/__snapshots__/View.js.snap
+++ b/__tests__/jest/components/__snapshots__/View.js.snap
@@ -4,6 +4,7 @@ exports[`<View /> name defaults to View 1`] = `
 <view
   name="View"
   resizingConstraint={undefined}
+  shadows={undefined}
   style={undefined}
 />
 `;
@@ -12,6 +13,7 @@ exports[`<View /> name passes its name 1`] = `
 <view
   name="foo"
   resizingConstraint={undefined}
+  shadows={undefined}
   style={undefined}
 />
 `;
@@ -20,6 +22,7 @@ exports[`<View /> passes its children 1`] = `
 <view
   name="View"
   resizingConstraint={undefined}
+  shadows={undefined}
   style={undefined}
 >
   foo
@@ -30,6 +33,7 @@ exports[`<View /> style accepts a StyleSheet ordinal 1`] = `
 <view
   name="View"
   resizingConstraint={undefined}
+  shadows={undefined}
   style={
     Object {
       "flex": 1,
@@ -42,6 +46,7 @@ exports[`<View /> style accepts a plain object 1`] = `
 <view
   name="View"
   resizingConstraint={undefined}
+  shadows={undefined}
   style={
     Object {
       "flex": 1,
@@ -54,6 +59,7 @@ exports[`<View /> style accepts an array of plain objects and/or StyleSheet ordi
 <view
   name="View"
   resizingConstraint={undefined}
+  shadows={undefined}
   style={
     Object {
       "flex": 1,

--- a/src/components/ShadowsPropTypes.js
+++ b/src/components/ShadowsPropTypes.js
@@ -1,0 +1,9 @@
+import * as PropTypes from 'prop-types';
+
+export default {
+  shadowColor: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  shadowOffset: { width: PropTypes.number, height: PropTypes.number },
+  shadowOpacity: PropTypes.number,
+  shadowRadius: PropTypes.number,
+  shadowSpread: PropTypes.number,
+};

--- a/src/components/Svg/Svg.js
+++ b/src/components/Svg/Svg.js
@@ -25,21 +25,6 @@ import Use from './Use';
 
 // $FlowFixMe
 export default class Svg extends React.Component {
-  static displayName = 'Svg';
-  static propTypes = {
-    ...View.propTypes,
-    opacity: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    // more detail https://svgwg.org/svg2-draft/coords.html#ViewBoxAttribute
-    viewBox: PropTypes.string,
-    preserveAspectRatio: PropTypes.string,
-  };
-
-  static defaultProps = {
-    preserveAspectRatio: 'xMidYMid meet',
-  };
-
   static Circle = Circle;
   static ClipPath = ClipPath;
   static Defs = Defs;
@@ -60,6 +45,20 @@ export default class Svg extends React.Component {
   static TextPath = TextPath;
   static TSpan = TSpan;
   static Use = Use;
+
+  static displayName = 'Svg';
+  static propTypes = {
+    ...View.propTypes,
+    opacity: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    // more detail https://svgwg.org/svg2-draft/coords.html#ViewBoxAttribute
+    viewBox: PropTypes.string,
+    preserveAspectRatio: PropTypes.string,
+  };
+  static defaultProps = {
+    preserveAspectRatio: 'xMidYMid meet',
+  };
 
   render() {
     const { children, ...rest } = this.props;

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -5,6 +5,7 @@ import { or } from 'airbnb-prop-types';
 import StyleSheet from '../stylesheet';
 import ViewStylePropTypes from './ViewStylePropTypes';
 import ResizingConstraintPropTypes from './ResizingConstraintPropTypes';
+import ShadowsPropTypes from './ShadowsPropTypes';
 
 // $FlowFixMe
 export default class View extends React.Component {
@@ -15,6 +16,11 @@ export default class View extends React.Component {
     resizingConstraint: PropTypes.shape({
       ...ResizingConstraintPropTypes,
     }),
+    shadows: PropTypes.arrayOf(
+      PropTypes.shape({
+        ...ShadowsPropTypes,
+      }),
+    ),
     children: PropTypes.node,
   };
 
@@ -28,6 +34,7 @@ export default class View extends React.Component {
         name={this.props.name}
         style={StyleSheet.flatten(this.props.style)}
         resizingConstraint={this.props.resizingConstraint}
+        shadows={this.props.shadows}
       >
         {this.props.children}
       </view>

--- a/src/renderers/ViewRenderer.js
+++ b/src/renderers/ViewRenderer.js
@@ -24,6 +24,7 @@ const VISIBLE_STYLES = [
   'shadowOffset',
   'shadowOpacity',
   'shadowRadius',
+  'shadowSpread',
   'backgroundColor',
   'borderColor',
   'borderTopColor',
@@ -44,7 +45,13 @@ const VISIBLE_STYLES = [
 
 const OVERFLOW_STYLES = ['overflow', 'overflowX', 'overflowY'];
 
-const SHADOW_STYLES = ['shadowColor', 'shadowOffset', 'shadowOpacity', 'shadowRadius'];
+const SHADOW_STYLES = [
+  'shadowColor',
+  'shadowOffset',
+  'shadowOpacity',
+  'shadowRadius',
+  'shadowSpread',
+];
 
 export default class ViewRenderer extends SketchRenderer {
   getDefaultGroupName() {
@@ -106,14 +113,32 @@ export default class ViewRenderer extends SketchRenderer {
     const fill = makeColorFill(backgroundColor);
     const content = makeShapeGroup(frame, [shapeLayer], [fill]);
 
+    let innerShadows = [];
+    let shadows = [];
+
     if (hasAnyDefined(style, SHADOW_STYLES)) {
       const shadow = [makeShadow(style)];
       if (style.shadowInner) {
-        content.style.innerShadows = shadow;
+        innerShadows = shadow;
       } else {
-        content.style.shadows = shadow;
+        shadows = shadow;
       }
     }
+
+    if (props.shadows) {
+      props.shadows.map((shadowStyle) => {
+        const shadow = makeShadow(shadowStyle);
+        if (shadowStyle.shadowInner) {
+          innerShadows.push(shadow);
+        } else {
+          shadows.push(shadow);
+        }
+        return shadowStyle;
+      });
+    }
+
+    content.style.innerShadows = innerShadows;
+    content.style.shadows = shadows;
 
     if (hasAnyDefined(style, OVERFLOW_STYLES)) {
       if (

--- a/src/types.js
+++ b/src/types.js
@@ -84,6 +84,7 @@ export type ViewStyle = {
   shadowOffset?: { width: number, height: number },
   shadowOpacity?: number,
   shadowRadius?: number,
+  shadowInner?: boolean,
   width?: number,
   height?: number,
   top?: number,
@@ -198,3 +199,14 @@ export type ResizeConstraints = {
   fixedHeight: boolean,
   fixedWidth: boolean,
 };
+
+export type SketchShadow = {
+  shadowColor: Color,
+  shadowOffset: { width: number, height: number },
+  shadowSpread: number,
+  shadowOpacity: number,
+  shadowRadius: number,
+  shadowInner: boolean,
+};
+
+export type SketchShadows = Array<SketchShadow>;


### PR DESCRIPTION
Add possibility to add multiple shadows and shadow spread #277

```

<View
    name={`Swatch ${name}`}
    style={{
      height: 96,
      width: 96,
      margin: 4,
      backgroundColor: hex,
      padding: 8,
    }}
    shadows={[
      {
        shadowColor: 'lime',
        shadowOffset: { width: 0, height: 7 },
        shadowOpacity: 0.12,
        shadowRadius: 4,
      },
      {
        shadowOffset: { width: 7, height: 3 },
        shadowOpacity: 0.12,
        shadowRadius: 4,
      },
    ]}
  >

```

<img width="873" alt="image" src="https://user-images.githubusercontent.com/197471/41254684-37657f86-6d92-11e8-8e48-a6b8ef34c01a.png">
