### PR TITLE
Fixed textDecoration missing value bug

### DIFF
--- a/src/jsonUtils/hacksForJSONImpl.js
+++ b/src/jsonUtils/hacksForJSONImpl.js
@@ -209,12 +209,15 @@ function createStringAttributes(textStyles: TextStyle): Object {
   const font = findFont(textStyles);
   const { textDecoration } = textStyles;
 
+  const underline = textDecoration && TEXT_DECORATION_UNDERLINE[textDecoration];
+  const strikethrough = textDecoration && TEXT_DECORATION_LINETHROUGH[textDecoration];
+
   const attribs: Object = {
     MSAttributedStringFontAttribute: font.fontDescriptor(),
     NSFont: font,
     NSParagraphStyle: makeParagraphStyle(textStyles),
-    NSUnderline: textDecoration ? TEXT_DECORATION_UNDERLINE[textDecoration] : 0,
-    NSStrikethrough: textDecoration ? TEXT_DECORATION_LINETHROUGH[textDecoration] : 0,
+    NSUnderline: textDecoration && underline ? underline : 0,
+    NSStrikethrough: textDecoration && strikethrough ? strikethrough : 0,
   };
 
   const color = makeColorFromCSS(textStyles.color || 'black');
@@ -260,7 +263,6 @@ export function makeEncodedAttributedString(textNodes: TextNodes) {
   const encodedAttribStr = MSAttributedString.encodeAttributedString(fullStr);
 
   const msAttribStr = MSAttributedString.alloc().initWithEncodedAttributedString(encodedAttribStr);
-
   return encodeSketchJSON(msAttribStr);
 }
 

--- a/src/jsonUtils/hacksForJSONImpl.js
+++ b/src/jsonUtils/hacksForJSONImpl.js
@@ -216,8 +216,8 @@ function createStringAttributes(textStyles: TextStyle): Object {
     MSAttributedStringFontAttribute: font.fontDescriptor(),
     NSFont: font,
     NSParagraphStyle: makeParagraphStyle(textStyles),
-    NSUnderline: textDecoration && underline ? underline : 0,
-    NSStrikethrough: textDecoration && strikethrough ? strikethrough : 0,
+    NSUnderline: underline || 0,
+    NSStrikethrough: strikethrough || 0,
   };
 
   const color = makeColorFromCSS(textStyles.color || 'black');


### PR DESCRIPTION
Fixes https://github.com/airbnb/react-sketchapp/issues/369

The issue was with the previous version of the ternaries, passing in a `textDecoration` that satisfied `NSUnderline` wouldn't satisfy `NSStrikethrough`, leaving the value of `NSStrikethrough` as undefined.

When passing into the JSON function later on, it would just leave the value blank, causing a parse error