### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ cache:
 notifications:
   email: false
 node_js:
-  - 'lts/*'
+  - 'node'
+  - '10'
+  - '8'
+  - '6'
 before_install:
   - brew update
   - brew cask install sketch # install Sketch


### PR DESCRIPTION
LTS are 6, 8 and 10. `lts/*` only uses the last LTS release, which would be 10 now. See https://github.com/nodejs/Release/blob/master/README.md