### PR TITLE
ci: use latest macOS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 os: osx
-osx_image: xcode8.3
 language: node_js
 cache:
   directories:


### PR DESCRIPTION
Currently the image for xCode 8.3 is used which is an older macOS version and not supported by Sketch.

See https://docs.travis-ci.com/user/reference/osx/#os-x-version