### PR TITLE
Flatten styles in exported Svg component

### DIFF
--- a/__tests__/jest/components/__snapshots__/Svg.js.snap
+++ b/__tests__/jest/components/__snapshots__/Svg.js.snap
@@ -4,6 +4,7 @@ exports[`<Svg /> passes its children 1`] = `
 <svg
   height="447"
   preserveAspectRatio="xMidYMid meet"
+  style={undefined}
   viewBox="0 0 494 447"
   width="494"
   xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Svg/Svg.js
+++ b/src/components/Svg/Svg.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { ViewPropTypes } from '../View';
+import StyleSheet from '../../stylesheet';
 import Circle from './Circle';
 import ClipPath from './ClipPath';
 import Defs from './Defs';
@@ -82,8 +83,12 @@ export default class Svg extends React.Component {
   };
 
   render() {
-    const { children, ...rest } = this.props;
+    const { children, style, ...rest } = this.props;
 
-    return <svg {...rest}>{children}</svg>;
+    return (
+      <svg {...rest} style={StyleSheet.flatten(style)}>
+        {children}
+      </svg>
+    );
   }
 }


### PR DESCRIPTION
This fixes styles created with `StyleSheet.create` not working on `<Svg />` elements