### PR TITLE
Add viewport preset prop to Artboard

### DIFF
--- a/__tests__/jest/components/Artboard.js
+++ b/__tests__/jest/components/Artboard.js
@@ -58,5 +58,22 @@ describe('<Artboard />', () => {
 
       expect(tree).toMatchSnapshot();
     });
+
+    it('accepts artboard viewport preset', () => {
+      const tree = renderer
+        .create(
+          <Artboard
+            style={{ flex: 1, width: 360, height: 1280 }}
+            viewport={{
+              name: 'Mobile',
+              width: 360,
+              height: 640,
+            }}
+          />,
+        )
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
   });
 });

--- a/__tests__/jest/components/__snapshots__/Artboard.js.snap
+++ b/__tests__/jest/components/__snapshots__/Artboard.js.snap
@@ -55,3 +55,23 @@ exports[`<Artboard /> style accepts an array of plain objects and/or StyleSheet 
   }
 />
 `;
+
+exports[`<Artboard /> style accepts artboard viewport preset 1`] = `
+<artboard
+  name="Artboard"
+  style={
+    Object {
+      "flex": 1,
+      "height": 1280,
+      "width": 360,
+    }
+  }
+  viewport={
+    Object {
+      "height": 640,
+      "name": "Mobile",
+      "width": 360,
+    }
+  }
+/>
+`;

--- a/docs/API.md
+++ b/docs/API.md
@@ -138,12 +138,12 @@ Wrapper for Sketch's Artboards. Requires a [`<Page>`](#page) component as a pare
 
 #### props
 
-| Prop | Type | Default | Note |
-| --- | --- | --- | --- |
-| `name` | `String` |  | The name to be displayed in the Sketch Layer List |
-| `children` | `Node` |  |  |
-| `style` | [`Style`](/docs/styling.md) |  |  |
-| `viewport` | `Viewport` |  | Object: { name: string, width: number, height: number} |
+| Prop       | Type                        | Default | Note                                                   |
+| ---------- | --------------------------- | ------- | ------------------------------------------------------ |
+| `name`     | `String`                    |         | The name to be displayed in the Sketch Layer List      |
+| `children` | `Node`                      |         |                                                        |
+| `style`    | [`Style`](/docs/styling.md) |         |                                                        |
+| `viewport` | `Viewport`                  |         | Object: { name: string, width: number, height: number} |
 
 #### Examples
 
@@ -164,7 +164,7 @@ Mobile screen artboard with viewport preset (supports scrolling in prototypes).
 
 ```js
 <Artboard
-  name="Home / Mobile"
+  name="Home/Mobile"
   style={{
     width: 360,
     height: 1280,
@@ -214,8 +214,8 @@ A red box / 'red screen of death' error handler. Thanks to [commissure/redbox-re
 
 #### Props
 
-| Prop | Type | Default | Note |
-| --- | --- | --- | --- |
+| Prop    | Type                                                                                              | Default      | Note                      |
+| ------- | ------------------------------------------------------------------------------------------------- | ------------ | ------------------------- |
 | `error` | [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) | **required** | A JavaScript Error object |
 
 #### Example
@@ -295,11 +295,11 @@ Text primitives
 
 #### Props
 
-| Prop | Type | Default | Note |
-| --- | --- | --- | --- |
-| `name` | `String` |  | The name to be displayed in the Sketch Layer List |
-| `children` | `String` |  |  |
-| `style` | [`Style`](/docs/styling.md) |  |  |
+| Prop       | Type                        | Default | Note                                              |
+| ---------- | --------------------------- | ------- | ------------------------------------------------- |
+| `name`     | `String`                    |         | The name to be displayed in the Sketch Layer List |
+| `children` | `String`                    |         |                                                   |
+| `style`    | [`Style`](/docs/styling.md) |         |                                                   |
 
 #### Example
 
@@ -323,11 +323,11 @@ View primitives
 
 #### Props
 
-| Prop | Type | Default | Note |
-| --- | --- | --- | --- |
-| `name` | `String` |  | The name to be displayed in the Sketch Layer List |
-| `children` | `Node` |  |  |
-| `style` | [`Style`](/docs/styling.md) |  |  |
+| Prop       | Type                        | Default | Note                                              |
+| ---------- | --------------------------- | ------- | ------------------------------------------------- |
+| `name`     | `String`                    |         | The name to be displayed in the Sketch Layer List |
+| `children` | `Node`                      |         |                                                   |
+| `style`    | [`Style`](/docs/styling.md) |         |                                                   |
 
 #### Example
 
@@ -597,11 +597,11 @@ Returns a react component which is an can be used to render instances of the sym
 
 #### Parameters
 
-| Parameter | Type | Default | Note |
-| --- | --- | --- | --- |
-| `node` | `Node` |  | The node object that will be rendered as a symbol |
-| `name` | `String` | The node name | Optional name for the symbol, string can include backslashes to organize these symbols with Sketch. For example `squares/blue` |
-| `document` | `Object` | The current document | The Sketch document to make the symbol in |
+| Parameter  | Type     | Default              | Note                                                                                                                           |
+| ---------- | -------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `node`     | `Node`   |                      | The node object that will be rendered as a symbol                                                                              |
+| `name`     | `String` | The node name        | Optional name for the symbol, string can include backslashes to organize these symbols with Sketch. For example `squares/blue` |
+| `document` | `Object` | The current document | The Sketch document to make the symbol in                                                                                      |
 
 ### `getSymbolComponentByName(name)`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -138,19 +138,41 @@ Wrapper for Sketch's Artboards. Requires a [`<Page>`](#page) component as a pare
 
 #### props
 
-| Prop       | Type                        | Default | Note                                              |
-| ---------- | --------------------------- | ------- | ------------------------------------------------- |
-| `name`     | `String`                    |         | The name to be displayed in the Sketch Layer List |
-| `children` | `Node`                      |         |                                                   |
-| `style`    | [`Style`](/docs/styling.md) |         |                                                   |
+| Prop | Type | Default | Note |
+| --- | --- | --- | --- |
+| `name` | `String` |  | The name to be displayed in the Sketch Layer List |
+| `children` | `Node` |  |  |
+| `style` | [`Style`](/docs/styling.md) |  |  |
+| `viewport` | `Viewport` |  | Object: { name: string, width: number, height: number} |
 
-#### Example
+#### Examples
+
+Hello world with width of 480px.
 
 ```js
 <Artboard
   name="My Artboard"
   style={{
     width: 480,
+  }}
+>
+  <Text>Hello world!</Text>
+</Artboard>
+```
+
+Mobile screen artboard with viewport preset (supports scrolling in prototypes).
+
+```js
+<Artboard
+  name="Home / Mobile"
+  style={{
+    width: 360,
+    height: 1280,
+  }}
+  viewport={{
+    name: 'Mobile',
+    width: 360,
+    height: 640,
   }}
 >
   <Text>Hello world!</Text>
@@ -192,8 +214,8 @@ A red box / 'red screen of death' error handler. Thanks to [commissure/redbox-re
 
 #### Props
 
-| Prop    | Type                                                                                              | Default      | Note                      |
-| ------- | ------------------------------------------------------------------------------------------------- | ------------ | ------------------------- |
+| Prop | Type | Default | Note |
+| --- | --- | --- | --- |
 | `error` | [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) | **required** | A JavaScript Error object |
 
 #### Example
@@ -273,11 +295,11 @@ Text primitives
 
 #### Props
 
-| Prop       | Type                        | Default | Note                                              |
-| ---------- | --------------------------- | ------- | ------------------------------------------------- |
-| `name`     | `String`                    |         | The name to be displayed in the Sketch Layer List |
-| `children` | `String`                    |         |                                                   |
-| `style`    | [`Style`](/docs/styling.md) |         |                                                   |
+| Prop | Type | Default | Note |
+| --- | --- | --- | --- |
+| `name` | `String` |  | The name to be displayed in the Sketch Layer List |
+| `children` | `String` |  |  |
+| `style` | [`Style`](/docs/styling.md) |  |  |
 
 #### Example
 
@@ -301,11 +323,11 @@ View primitives
 
 #### Props
 
-| Prop       | Type                        | Default | Note                                              |
-| ---------- | --------------------------- | ------- | ------------------------------------------------- |
-| `name`     | `String`                    |         | The name to be displayed in the Sketch Layer List |
-| `children` | `Node`                      |         |                                                   |
-| `style`    | [`Style`](/docs/styling.md) |         |                                                   |
+| Prop | Type | Default | Note |
+| --- | --- | --- | --- |
+| `name` | `String` |  | The name to be displayed in the Sketch Layer List |
+| `children` | `Node` |  |  |
+| `style` | [`Style`](/docs/styling.md) |  |  |
 
 #### Example
 
@@ -575,11 +597,11 @@ Returns a react component which is an can be used to render instances of the sym
 
 #### Parameters
 
-| Parameter  | Type     | Default              | Note                                                                                                                           |
-| ---------- | -------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `node`     | `Node`   |                      | The node object that will be rendered as a symbol                                                                              |
-| `name`     | `String` | The node name        | Optional name for the symbol, string can include backslashes to organize these symbols with Sketch. For example `squares/blue` |
-| `document` | `Object` | The current document | The Sketch document to make the symbol in                                                                                      |
+| Parameter | Type | Default | Note |
+| --- | --- | --- | --- |
+| `node` | `Node` |  | The node object that will be rendered as a symbol |
+| `name` | `String` | The node name | Optional name for the symbol, string can include backslashes to organize these symbols with Sketch. For example `squares/blue` |
+| `document` | `Object` | The current document | The Sketch document to make the symbol in |
 
 ### `getSymbolComponentByName(name)`
 

--- a/src/components/Artboard.js
+++ b/src/components/Artboard.js
@@ -5,6 +5,12 @@ import { or } from 'airbnb-prop-types';
 import StyleSheet from '../stylesheet';
 import ViewStylePropTypes from './ViewStylePropTypes';
 
+const ViewportPropTypes = {
+  name: PropTypes.string,
+  width: PropTypes.number,
+  height: PropTypes.number,
+};
+
 // $FlowFixMe
 export default class Artboard extends React.Component {
   static propTypes = {
@@ -12,6 +18,7 @@ export default class Artboard extends React.Component {
     style: or([PropTypes.shape(ViewStylePropTypes), PropTypes.number]),
     name: PropTypes.string,
     children: PropTypes.node,
+    viewport: PropTypes.shape(ViewportPropTypes),
   };
 
   static defaultProps = {
@@ -20,7 +27,11 @@ export default class Artboard extends React.Component {
 
   render() {
     return (
-      <artboard style={StyleSheet.flatten(this.props.style)} name={this.props.name}>
+      <artboard
+        style={StyleSheet.flatten(this.props.style)}
+        name={this.props.name}
+        viewport={this.props.viewport}
+      >
         {this.props.children}
       </artboard>
     );

--- a/src/renderers/ArtboardRenderer.js
+++ b/src/renderers/ArtboardRenderer.js
@@ -27,6 +27,13 @@ export default class ArtboardRenderer extends SketchRenderer {
       isVisible: true,
       backgroundColor: color || makeColorFromCSS('white'),
       hasBackgroundColor: color !== undefined,
+      ...(props.viewport && {
+        presetDictionary: {
+          allowResizedMatching: 0,
+          offersLandscapeVariant: 1,
+          ...props.viewport,
+        },
+      }),
     };
   }
 }


### PR DESCRIPTION
Adds a viewport preset prop to Artboard to allow for scrolling artboards in prototypes.

Includes documentation. Example:

```jsx
<Artboard
  style={{
    width: 360,
    height: 1280,
  }}
  viewport={{
    name: 'Mobile',
    width: 360,
    height: 640,
  }}
/>
```

I'd add a viewport preset example, but don't want to pollute the repo with too many examples, should I create a new repo under my account: `react-sketchapp-examples`?

fixes #434 