### PR TITLE
Fix the build for basic-setup-typescript

### DIFF
--- a/examples/basic-setup-typescript/README.md
+++ b/examples/basic-setup-typescript/README.md
@@ -47,8 +47,11 @@ Here is a reference `tsconfig.json`:
     "strict": true,
     "outDir": "./.ts-compiled",
     "rootDir": "./src",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node"
   },
-  "include": ["./src/**/*"]
+  "include": [
+    "./src/**/*"
+  ]
 }
 ```

--- a/examples/basic-setup-typescript/tsconfig.json
+++ b/examples/basic-setup-typescript/tsconfig.json
@@ -7,7 +7,8 @@
     "strict": true,
     "outDir": "./.ts-compiled",
     "rootDir": "./src",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node"
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
Closes https://github.com/airbnb/react-sketchapp/issues/360

Currently, these commands fail to build:
```
git clone https://github.com/airbnb/react-sketchapp.git
cd react-sketchapp/examples/basic-setup-typescript
yarn
```

This change allows the build to pass.