### PR TITLE
Pass 'masterName' instead of 'name' to generateID function

### DIFF
--- a/src/symbol.tsx
+++ b/src/symbol.tsx
@@ -165,7 +165,7 @@ export const makeSymbol = (
   const existingSymbol = existingSymbols.find(symbolMaster => symbolMaster.name === masterName);
   const symbolID = existingSymbol
     ? existingSymbol.symbolID
-    : generateID(`symbolID:${masterName}`, !!name);
+    : generateID(`symbolID:${masterName}`, !!masterName);
 
   const symbolMaster = flexToSketchJSON(
     buildTree(


### PR DESCRIPTION
This resolves the following error when running the generated Sketch plugin that uses `makeSymbol` (the error can reproduced by running the `symbols` example):

> ReferenceError: Can't find variable: name