### PR TITLE
Contribution URL fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ Found a novel use? We'd love to hear about it!
 - [Universal Rendering](http://airbnb.io/react-sketchapp/docs/guides/universal-rendering.html)
 - [Data Fetching](http://airbnb.io/react-sketchapp/docs/guides/data-fetching.html)
 - [FAQ](http://airbnb.io/react-sketchapp/docs/FAQ.html)
-- [Contributing](http://airbnb.io/react-sketchapp/CONTRIBUTING.html)
+- [Contributing](https://github.com/airbnb/react-sketchapp/blob/master/.github/CONTRIBUTING.md)


### PR DESCRIPTION
URL to contributing guidelines seems not to work.
#460 