### PR TITLE
Add shadowInner style to docs

### DIFF
--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -76,7 +76,7 @@ Components use CSS styles + FlexBox layout.
 | `shadowOffset` | `{ width: number, height: number }` | ✅ |
 | `shadowOpacity` | `number` | ✅ |
 | `shadowRadius` | `number` &#124; `percentage` | ✅ |
-| [see `react-sketchapp` only styles](#react-sketchapp-only-shadow-styles)   | | |
+| [see `react-sketchapp` only styles](#react-sketchapp-only-styles)   | | |
 
 ## Type Styles
 

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -6,12 +6,6 @@ Components use CSS styles + FlexBox layout.
 
 | property | type | supported? |
 | --- | --- | --- |
-| `shadowColor` | `Color` | ✅ |
-| `shadowOffset` | `{ width: number, height: number }` | ✅ |
-| `shadowOpacity` | `number` | ✅ |
-| `shadowSpread` | `number` | ✅ |
-| `shadowInner` | `boolean` | ✅ |
-| `shadowRadius` | `number` &#124; `percentage` | ✅ |
 | `width` | `number` &#124; `percentage` | ✅ |
 | `height` | `number` &#124; `percentage` | ✅ |
 | `top` | `number` &#124; `percentage` | ✅ |
@@ -73,6 +67,22 @@ Components use CSS styles + FlexBox layout.
 | `borderBottomWidth` | `number` &#124; `percentage` | ✅ |
 | `borderLeftWidth` | `number` &#124; `percentage` | ✅ |
 | `opacity` | `number` | ✅ |
+
+## Shadow Styles
+
+| property | type | supported? |
+| --- | --- | --- |
+| `shadowColor` | `Color` | ✅ |
+| `shadowOffset` | `{ width: number, height: number }` | ✅ |
+| `shadowOpacity` | `number` | ✅ |
+| `shadowRadius` | `number` &#124; `percentage` | ✅ |
+
+### `react-sketchapp` only shadow styles:
+
+| property | type | supported? |
+| --- | --- | --- |
+| `shadowSpread` | `number` | ✅ |
+| `shadowInner` | `boolean` | ✅ |
 
 ## Type Styles
 

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -10,6 +10,7 @@ Components use CSS styles + FlexBox layout.
 | `shadowOffset` | `{ width: number, height: number }` | ✅ |
 | `shadowOpacity` | `number` | ✅ |
 | `shadowSpread` | `number` | ✅ |
+| `shadowInner` | `boolean` | ✅ |
 | `shadowRadius` | `number` &#124; `percentage` | ✅ |
 | `width` | `number` &#124; `percentage` | ✅ |
 | `height` | `number` &#124; `percentage` | ✅ |

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -72,17 +72,11 @@ Components use CSS styles + FlexBox layout.
 
 | property | type | supported? |
 | --- | --- | --- |
-| `shadowColor` | `Color` | ✅ |
+| `shadowColor` | `Color`                                                  | ✅ |
 | `shadowOffset` | `{ width: number, height: number }` | ✅ |
 | `shadowOpacity` | `number` | ✅ |
 | `shadowRadius` | `number` &#124; `percentage` | ✅ |
-
-### `react-sketchapp` only shadow styles:
-
-| property | type | supported? |
-| --- | --- | --- |
-| `shadowSpread` | `number` | ✅ |
-| `shadowInner` | `boolean` | ✅ |
+| [see `react-sketchapp` only styles](#react-sketchapp-only-shadow-styles)   | | |
 
 ## Type Styles
 
@@ -103,6 +97,13 @@ Components use CSS styles + FlexBox layout.
 | `writingDirection` | `auto` &#124; `ltr` &#124; `rtl` | ⛔️ |
 | `opacity` | `number` | ✅ |
 | `percentage` | `points` &#124; `percentages` | ✅ |
+
+## React Sketch.app Only Styles
+
+| property | type | supported? |
+| --- | --- | --- |
+| `shadowSpread` | `number` | ✅ |
+| `shadowInner` | `boolean` | ✅ |
 
 ## Examples
 

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -72,11 +72,10 @@ Components use CSS styles + FlexBox layout.
 
 | property | type | supported? |
 | --- | --- | --- |
-| `shadowColor` | `Color`                                                  | ✅ |
+| `shadowColor` | `Color` | ✅ |
 | `shadowOffset` | `{ width: number, height: number }` | ✅ |
 | `shadowOpacity` | `number` | ✅ |
 | `shadowRadius` | `number` &#124; `percentage` | ✅ |
-| [see `react-sketchapp` only styles](#react-sketchapp-only-styles)   | | |
 
 ## Type Styles
 
@@ -98,7 +97,9 @@ Components use CSS styles + FlexBox layout.
 | `opacity` | `number` | ✅ |
 | `percentage` | `points` &#124; `percentages` | ✅ |
 
-## React Sketch.app Only Styles
+## Styles Specific To `react-sketchapp`
+
+Some properties are Sketch specific and won't work cross-platform but give you a better control over your components.
 
 | property | type | supported? |
 | --- | --- | --- |


### PR DESCRIPTION
Add `shadowInner` to `styling.md` docs README.

Code reference: https://github.com/airbnb/react-sketchapp/blob/cee20156d3795c3e4899e746aafde7cd22a149e6/src/jsonUtils/style.ts#L89

**Related issues/PRs**

> #160 