### PR TITLE
compatible with fontWeight in number

### DIFF
--- a/src/jsonUtils/sketchImpl/findFontName.ts
+++ b/src/jsonUtils/sketchImpl/findFontName.ts
@@ -94,12 +94,7 @@ export const findFont = (style: TextStyle): NSFont => {
   const defaultFontSize = 14;
 
   const fontSize = style.fontSize ? style.fontSize : defaultFontSize;
-  let fontWeight =
-    style.fontWeight &&
-    String(style.fontWeight).toLowerCase() &&
-    FONT_WEIGHTS[String(style.fontWeight).toLowerCase()]
-      ? FONT_WEIGHTS[String(style.fontWeight).toLowerCase()]
-      : defaultFontWeight;
+  let fontWeight = FONT_WEIGHTS[String(style.fontWeight).toLowerCase()] || defaultFontWeight;
 
   let familyName = defaultFontFamily;
   let isItalic = false;

--- a/src/jsonUtils/sketchImpl/findFontName.ts
+++ b/src/jsonUtils/sketchImpl/findFontName.ts
@@ -94,9 +94,12 @@ export const findFont = (style: TextStyle): NSFont => {
   const defaultFontSize = 14;
 
   const fontSize = style.fontSize ? style.fontSize : defaultFontSize;
-  let fontWeight = style.fontWeight
-    ? FONT_WEIGHTS[style.fontWeight.toLowerCase()]
-    : defaultFontWeight;
+  let fontWeight =
+    style.fontWeight &&
+    String(style.fontWeight).toLowerCase() &&
+    FONT_WEIGHTS[String(style.fontWeight).toLowerCase()]
+      ? FONT_WEIGHTS[String(style.fontWeight).toLowerCase()]
+      : defaultFontWeight;
 
   let familyName = defaultFontFamily;
   let isItalic = false;


### PR DESCRIPTION
The incoming fontWeight is likely to be a number (like `500`) instead of a string (`'500'`), or even other things... [example](https://github.com/ant-design/antd-sketchapp/pull/41)

Maybe it would be safer to avoid these cases in a proactive way.