### PR TITLE
Create getting started docs page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [Guides](/docs/guides/README.md)
   - [Getting Started](/docs/guides/getting-started.md)
   - [Using `skpm` as a build system](/docs/guides/using-skpm.md)
+  - [Rendering](rendering.md)
   - [Data Fetching](/docs/guides/data-fetching.md)
   - [Universal Rendering](/docs/guides/universal-rendering.md)
   - [Styling](/docs/guides/styling.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 - [Introduction](/README.md)
 - [Guides](/docs/guides/README.md)
+  - [Getting Started](/docs/guides/getting-started.md)
   - [Using `skpm` as a build system](/docs/guides/using-skpm.md)
   - [Data Fetching](/docs/guides/data-fetching.md)
   - [Universal Rendering](/docs/guides/universal-rendering.md)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -2,6 +2,7 @@
 
 How to use `react-sketchapp` for fun and profit.
 
+- [Getting Started](getting-started.md)
 - [Using `skpm` as a build system](using-skpm.md)
 - [Data Fetching](data-fetching.md)
 - [Universal Rendering](universal-rendering.md)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -4,6 +4,7 @@ How to use `react-sketchapp` for fun and profit.
 
 - [Getting Started](getting-started.md)
 - [Using `skpm` as a build system](using-skpm.md)
+- [Rendering](rendering.md)
 - [Data Fetching](data-fetching.md)
 - [Universal Rendering](universal-rendering.md)
 - [Styling](styling.md)

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -93,10 +93,8 @@ const App = () => (
 
 export default () => {
   const documents = sketch.getDocuments();
-  const document =
-    Array.isArray(documents) && documents.length >= 1 // if there are any open documents
-      ? documents[0] // select the last active document
-      : new sketch.Document(); // or create a new document
+  const document = sketch.getSelectedDocument() // get the current document
+    || new sketch.Document(); // or create a new document
 
   render(<App />, document);
 };

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -17,7 +17,7 @@ You will need npm, Node and Sketch.
 
 **Replace** `my-app` with your desired project name:
 
-### Installation
+### Installation
 
 ```bash
 npm install --global skpm
@@ -25,7 +25,7 @@ skpm create my-app --template=airbnb/react-sketchapp # template is a GitHub repo
 cd my-app
 ```
 
-### Setup
+### Setup
 
 You can now open `my-app` in your code editor of choice. You will see a `src` folder with a `manifest.json` file and Sketch entrypoint (e.g. `my-command.js`). If you wish to rename `my-command.js`, you can do so and update the file name in `script` in `manifest.json`
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -125,8 +125,8 @@ const getDocumentByName = name => {
   return (sketch.getDocuments() || []).find(doc => {
     const nativeDoc = doc.sketchObject || {};
     // (unstable/native API)
-    const name = nativeDoc.displayName ? nativeDoc.displayName() : '';
-    if (name.trim() === name) {
+    const docName = nativeDoc.displayName ? nativeDoc.displayName() : '';
+    if (docName.trim() === name) {
       return doc;
     }
   });

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,140 @@
+# Getting Started
+
+You can create a `react-sketchapp` project with `skpm`, by cloning a ready-made [example](../examples.md), or by manually setting up the `package.json` and `manifest.json` scripts (advanced usage).
+
+## Environment Setup
+
+You will need npm, Node and Sketch.
+
+- Code editor e.g. [VSCode](https://code.visualstudio.com/), [Atom](https://atom.io/)
+- Node.js & `npm` – [install with Homebrew](https://nodejs.org/en/download/package-manager/#macos) (or install with [Node Version Manager](https://nodejs.org/en/download/package-manager/#nvm))
+- [Sketch](https://www.sketch.com/)
+  - requires macOS
+
+## Creating a Project With Skpm
+
+**Replace** `my-app` with your desired project name:
+
+### Installation
+
+```bash
+npm i -g skpm
+skpm create my-app --template=airbnb/react-sketchapp # template is a GitHub repo
+cd my-app
+```
+
+### Setup
+
+You can now open `my-app` in your code editor of choice. You will see a `src` folder with a `manifest.json` file and Sketch entrypoint (e.g. `my-command.js`). If you wish to rename `my-command.js`, you can do so and update the file name in `script` in `manifest.json`
+
+Example modifications (assuming we want to rename the entrypoint file to `main.js` and don't want to have sub-commands):
+
+`src/manifest.json`
+
+```diff
+  "commands": [
+    {
+-      "name": "my-command",
++      "name": "My App Name: Sketch Components"
+-      "identifier": "my-command-identifier",
++      "identifier": "main",
+-      "script": "./my-command.js"
++      "script": "./main.js"
+    }
+  ],
+  "menu": {
+-    "title": "my-app",
+-    "items": [
+-      "my-command-identifier"
+-    ]
++    "isRoot": true,
++    "items": [
++      "main"
++    ]
++  }
+  }
+```
+
+### Rendering to Sketch
+
+To render your app to Sketch, open the Sketch application, create a new blank document, then go to your Terminal and run:
+
+```bash
+// Make sure you've already done `cd my-app`
+npm run render
+```
+
+If you forget to create a new document, you may get an error saying `null is not an object`. You can handle this case with the instructions below:
+
+### Rendering to Multiple Pages or New Documents
+
+`src/my-command.js` (or whatever file you may have renamed it to).
+
+```js
+import React from 'react';
+import { render } from 'react-sketchapp';
+
+import { render, Document, Page } from 'react-sketchapp';
+
+const App = () => (
+  <Document>
+    <Page name="Page 1">
+      <Artboard>
+        <Text>Hello World!</Text>
+      </Artboard>
+    </Page>
+    <Page name="Page 2">
+      <Artboard>
+        <Text>Hello World, again!</Text>
+      </Artboard>
+    </Page>
+  </Document>
+);
+
+export default () => {
+  const documents = sketch.getDocuments();
+  const document =
+    Array.isArray(documents) && documents.length >= 1 // if there are any open documents
+      ? documents[0] // select the last active document
+      : new sketch.Document(); // or create a new document
+
+  render(<App />, document);
+};
+```
+
+Here are some examples of retrieving our desired target document:
+
+**Get selected document**
+
+```js
+const sketch = require('sketch');
+
+export default () => {
+  const document = sketch.getSelectedDocument();
+
+  render(<App />, document);
+};
+```
+
+**Get document by name**
+
+```js
+const sketch = require('sketch');
+
+const getDocumentByName = name => {
+  return (sketch.getDocuments() || []).find(doc => {
+    const nativeDoc = doc.sketchObject || {};
+    // (unstable/native API)
+    const name = nativeDoc.displayName ? nativeDoc.displayName() : '';
+    if (name.trim() === name) {
+      return doc;
+    }
+  });
+};
+
+export default () => {
+  const document = getDocumentByName('My App Design') || new sketch.Document(); // Fallback to new document if document not found
+
+  render(<App />, document);
+};
+```

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -95,8 +95,6 @@ export default () => {
   const documents = sketch.getDocuments();
   const document = sketch.getSelectedDocument() // get the current document
     || new sketch.Document(); // or create a new document
-
-  render(<App />, document);
 };
 ```
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -60,7 +60,7 @@ Example modifications (assuming we want to rename the entrypoint file to `main.j
 To render your app to Sketch, open the Sketch application, create a new blank document, then go to your Terminal and run:
 
 ```bash
-// Make sure you've already done `cd my-app`
+# Make sure you've already done `cd my-app`
 npm run render
 ```
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -6,6 +6,8 @@ You can create a `react-sketchapp` project with `skpm`, by cloning a ready-made 
 
 You will need npm, Node and Sketch.
 
+- Terminal (if you’re new to the command line, this [guide](https://medium.com/32pixels/the-designers-guide-to-the-osx-command-prompt-71b0016cac31) may help)
+  - You need to make sure `git` is installed – type `git --version` in your Terminal to check if it's installed, if it isn’t, you should be prompted to install via “command line developer tools”.
 - Code editor e.g. [VSCode](https://code.visualstudio.com/), [Atom](https://atom.io/)
 - Node.js & `npm` – [install with Homebrew](https://nodejs.org/en/download/package-manager/#macos) (or install with [Node Version Manager](https://nodejs.org/en/download/package-manager/#nvm))
 - [Sketch](https://www.sketch.com/)
@@ -18,7 +20,7 @@ You will need npm, Node and Sketch.
 ### Installation
 
 ```bash
-npm i -g skpm
+npm install --global skpm
 skpm create my-app --template=airbnb/react-sketchapp # template is a GitHub repo
 cd my-app
 ```
@@ -64,73 +66,6 @@ To render your app to Sketch, open the Sketch application, create a new blank do
 npm run render
 ```
 
-If you forget to create a new document, you may get an error saying `null is not an object`. You can handle this case with the instructions below:
+You can pass the target Sketch container layer (i.e. document, group or page object) to the `render` function in your Sketch plugin entrypoint file, using the Sketch API: `render(<App />, sketch.getSelectedDocument()`.
 
-### Rendering to Multiple Pages or New Documents
-
-`src/my-command.js` (or whatever file you may have renamed it to).
-
-```js
-import React from 'react';
-import { render } from 'react-sketchapp';
-
-import { render, Document, Page } from 'react-sketchapp';
-
-const App = () => (
-  <Document>
-    <Page name="Page 1">
-      <Artboard>
-        <Text>Hello World!</Text>
-      </Artboard>
-    </Page>
-    <Page name="Page 2">
-      <Artboard>
-        <Text>Hello World, again!</Text>
-      </Artboard>
-    </Page>
-  </Document>
-);
-
-export default () => {
-  const documents = sketch.getDocuments();
-  const document = sketch.getSelectedDocument() // get the current document
-    || new sketch.Document(); // or create a new document
-};
-```
-
-Here are some examples of retrieving our desired target document:
-
-**Get selected document**
-
-```js
-const sketch = require('sketch');
-
-export default () => {
-  const document = sketch.getSelectedDocument();
-
-  render(<App />, document);
-};
-```
-
-**Get document by name**
-
-```js
-const sketch = require('sketch');
-
-const getDocumentByName = name => {
-  return (sketch.getDocuments() || []).find(doc => {
-    const nativeDoc = doc.sketchObject || {};
-    // (unstable/native API)
-    const docName = nativeDoc.displayName ? nativeDoc.displayName() : '';
-    if (docName.trim() === name) {
-      return doc;
-    }
-  });
-};
-
-export default () => {
-  const document = getDocumentByName('My App Design') || new sketch.Document(); // Fallback to new document if document not found
-
-  render(<App />, document);
-};
-```
+For more info on rendering to Sketch, see the [rendering](./rendering.md) page.

--- a/docs/guides/rendering.md
+++ b/docs/guides/rendering.md
@@ -1,0 +1,74 @@
+# Rendering Guide
+
+You can use the Sketch API to select Sketch containers such as documents, pages or groups, to pass through to the `render` function.
+
+### Rendering to Multiple Pages or New Documents
+
+`src/my-command.js` (or whatever file your Sketch plugin entrypoint is).
+
+```js
+import React from 'react';
+import { render, Document, Page } from 'react-sketchapp';
+
+// <Document> wrapper is required if you want to use multiple pages
+const App = () => (
+  <Document>
+    <Page name="Page 1">
+      <Artboard>
+        <Text>Hello World!</Text>
+      </Artboard>
+    </Page>
+    <Page name="Page 2">
+      <Artboard>
+        <Text>Hello World, again!</Text>
+      </Artboard>
+    </Page>
+  </Document>
+);
+
+export default () => {
+  const documents = sketch.getDocuments();
+  const document =
+    sketch.getSelectedDocument() || new sketch.Document(); // get the current document // or create a new document
+};
+```
+
+## Rendering to Selected Document
+
+This will render to the last active document. If there is no document open, document will be undefined and you will get an error, so you can add `|| new sketch.Document()` as a fallback to handle this.
+
+```js
+import sketch from 'sketch';
+import { render } from 'react-sketchapp';
+
+// const App = () => ... or import App from './App';
+
+export default () => {
+  const document = sketch.getSelectedDocument();
+
+  render(<App />, document);
+};
+```
+
+## Rendering to Document by Name
+
+We can select a document by name, by looping through `sketch.getDocuments()` and checking `doc.path` inside the loop.
+
+```js
+import sketch from 'sketch';
+import { render } from 'react-sketchapp';
+
+// const App = () => ... or import App from './App';
+
+const getDocumentByName = name => {
+  return (sketch.getDocuments() || []).find(doc => {
+    return doc.path && path.basename(doc.path, '.sketch') === name;
+  });
+};
+
+export default () => {
+  const document = getDocumentByName('My App Design') || new sketch.Document(); // Fallback to new document if document not found
+
+  render(<App />, document);
+};
+```

--- a/docs/guides/rendering.md
+++ b/docs/guides/rendering.md
@@ -55,6 +55,7 @@ export default () => {
 We can select a document by name, by looping through `sketch.getDocuments()` and checking `doc.path` inside the loop.
 
 ```js
+import path from 'path';
 import sketch from 'sketch';
 import { render } from 'react-sketchapp';
 

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -70,12 +70,12 @@ Components use CSS styles + FlexBox layout.
 
 ## Shadow Styles
 
-| property | type | supported? |
-| --- | --- | --- |
-| `shadowColor` | `Color` | ✅ |
-| `shadowOffset` | `{ width: number, height: number }` | ✅ |
-| `shadowOpacity` | `number` | ✅ |
-| `shadowRadius` | `number` &#124; `percentage` | ✅ |
+| property        | type                                | supported? |
+| --------------- | ----------------------------------- | ---------- |
+| `shadowColor`   | `Color`                             | ✅         |
+| `shadowOffset`  | `{ width: number, height: number }` | ✅         |
+| `shadowOpacity` | `number`                            | ✅         |
+| `shadowRadius`  | `number` &#124; `percentage`        | ✅         |
 
 ## Type Styles
 
@@ -101,10 +101,11 @@ Components use CSS styles + FlexBox layout.
 
 Some properties are Sketch specific and won't work cross-platform but give you a better control over your components.
 
-| property | type | supported? |
-| --- | --- | --- |
-| `shadowSpread` | `number` | ✅ |
-| `shadowInner` | `boolean` | ✅ |
+| property        | type                                         | supported? |
+| --------------- | -------------------------------------------- | ---------- |
+| `shadowSpread`  | `number`                                     | ✅         |
+| `shadowInner`   | `boolean`                                    | ✅         |
+| `textTransform` | `none` &#124; `uppercase` &#124; `lowercase` | ✅         |
 
 ## Examples
 

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -90,6 +90,7 @@ Components use CSS styles + FlexBox layout.
 | `textShadowOffset` | `{ width: number, height: number }` | ✅ |
 | `textShadowRadius` | `number` | ✅ |
 | `textShadowColor` | `Color` | ✅ |
+| `textTransform` | `none` &#124; `uppercase` &#124; `lowercase` | ✅ |
 | `letterSpacing` | `number` | ✅ |
 | `lineHeight` | `number` | ✅ |
 | `textAlign` | `auto` &#124; `left` &#124; `right` &#124; `center` &#124; `justify` | ✅ |
@@ -105,7 +106,6 @@ Some properties are Sketch specific and won't work cross-platform but give you a
 | --- | --- | --- |
 | `shadowSpread` | `number` | ✅ |
 | `shadowInner` | `boolean` | ✅ |
-| `textTransform` | `none` &#124; `uppercase` &#124; `lowercase` | ✅ |
 
 ## Examples
 

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -70,12 +70,12 @@ Components use CSS styles + FlexBox layout.
 
 ## Shadow Styles
 
-| property        | type                                | supported? |
-| --------------- | ----------------------------------- | ---------- |
-| `shadowColor`   | `Color`                             | ✅         |
-| `shadowOffset`  | `{ width: number, height: number }` | ✅         |
-| `shadowOpacity` | `number`                            | ✅         |
-| `shadowRadius`  | `number` &#124; `percentage`        | ✅         |
+| property | type | supported? |
+| --- | --- | --- |
+| `shadowColor` | `Color` | ✅ |
+| `shadowOffset` | `{ width: number, height: number }` | ✅ |
+| `shadowOpacity` | `number` | ✅ |
+| `shadowRadius` | `number` &#124; `percentage` | ✅ |
 
 ## Type Styles
 
@@ -101,11 +101,11 @@ Components use CSS styles + FlexBox layout.
 
 Some properties are Sketch specific and won't work cross-platform but give you a better control over your components.
 
-| property        | type                                         | supported? |
-| --------------- | -------------------------------------------- | ---------- |
-| `shadowSpread`  | `number`                                     | ✅         |
-| `shadowInner`   | `boolean`                                    | ✅         |
-| `textTransform` | `none` &#124; `uppercase` &#124; `lowercase` | ✅         |
+| property | type | supported? |
+| --- | --- | --- |
+| `shadowSpread` | `number` | ✅ |
+| `shadowInner` | `boolean` | ✅ |
+| `textTransform` | `none` &#124; `uppercase` &#124; `lowercase` | ✅ |
 
 ## Examples
 


### PR DESCRIPTION
Hopefully addresses #263 (there's overlap with the slow start PR, but decided to carry on the effort as a more general purpose getting started page, as it's been inactive). 

- Adds `textTransform` to docs (included in "React Sketch.app only" section, as `capitalize` isn't supported, unlike RN and web) fixes #491 
- Addresses #48 
- Addresses #23 