### PR TITLE
Create Page.Container component

### DIFF
--- a/src/components/PageContainer.tsx
+++ b/src/components/PageContainer.tsx
@@ -2,30 +2,26 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { or } from 'airbnb-prop-types';
 import StyleSheet from '../stylesheet';
-import PageContainer from './PageContainer';
 import PageStylePropTypes from './PageStylePropTypes';
 
 export const PagePropTypes = {
-  name: PropTypes.string,
   children: PropTypes.node,
   style: or([PropTypes.shape(PageStylePropTypes), PropTypes.number]),
 };
 
 type Props = PropTypes.InferProps<typeof PagePropTypes>;
 
-export default class Page extends React.Component<Props> {
+export default class PageContainer extends React.Component<Props> {
   static propTypes = PagePropTypes;
-  static Container = PageContainer;
 
   render() {
-    const { name, children, style, ...otherProps } = this.props;
-    const _name = name === 'Symbols' ? 'Symbols (renamed to avoid conflict)' : name;
+    const { children, style, ...otherProps } = this.props;
     const _style = StyleSheet.flatten(style);
 
     return (
-      <sketch_page name={_name} style={_style} {...otherProps}>
+      <sketch_pagecontainer style={_style} {...otherProps}>
         {children}
-      </sketch_page>
+      </sketch_pagecontainer>
     );
   }
 }

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -41,6 +41,11 @@ const getDefaultPage = (): SketchLayer => {
 };
 
 const renderContents = (tree: TreeNode | string, container: SketchLayer): SketchLayer => {
+  if (typeof tree !== 'string' && tree.type === 'sketch_pagecontainer') {
+    const children = tree.children || [];
+
+    return children.map(child => renderContents(child, container));
+  }
   const json = flexToSketchJSON(tree);
   const layer = fromSJSON(json, '119');
 

--- a/src/types/intrinsic.d.ts
+++ b/src/types/intrinsic.d.ts
@@ -5,6 +5,7 @@ declare module JSX {
     sketch_view: any;
     sketch_text: any;
     sketch_page: any;
+    sketch_pagecontainer: any;
     sketch_image: any;
     sketch_document: any;
     sketch_artboard: any;


### PR DESCRIPTION
I had a go at implementing a `<Page.Container>` component, to be able to wrap Artboards in a flexbox wrapper component, but without having the group rendering. I copied the implementation over from #291 

There's a bug with this though where if you remove artboards and save/rerender to Sketch, the deleted artboards remain.

fixes #342 