### PR TITLE
Fix rendering link in docs sidebar

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 - [Guides](/docs/guides/README.md)
   - [Getting Started](/docs/guides/getting-started.md)
   - [Using `skpm` as a build system](/docs/guides/using-skpm.md)
-  - [Rendering](rendering.md)
+  - [Rendering](/docs/guides/rendering.md)
   - [Data Fetching](/docs/guides/data-fetching.md)
   - [Universal Rendering](/docs/guides/universal-rendering.md)
   - [Styling](/docs/guides/styling.md)


### PR DESCRIPTION
Just noticed that the rendering link/page in docs sidebar is broken.