### PR TITLE
Local dev module aliasing for examples

### DIFF
--- a/examples/basic-setup-typescript/src/my-command.tsx
+++ b/examples/basic-setup-typescript/src/my-command.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import sketch from 'sketch';
 import { render, Artboard, Text, View } from 'react-sketchapp';
 import chroma from 'chroma-js';
 
@@ -67,5 +68,5 @@ export default () => {
     'TypeScript Blue': '#007ACC',
   };
 
-  render(<Document colors={colorList} />, context.document.currentPage());
+  render(<Document colors={colorList} />, sketch.getSelectedDocument().selectedPage);
 };

--- a/examples/basic-setup-typescript/src/types/sketch.d.ts
+++ b/examples/basic-setup-typescript/src/types/sketch.d.ts
@@ -1,0 +1,1 @@
+declare module 'sketch';

--- a/examples/basic-setup-typescript/webpack.skpm.config.js
+++ b/examples/basic-setup-typescript/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};

--- a/examples/basic-setup/src/my-command.js
+++ b/examples/basic-setup/src/my-command.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { render, Artboard, Text, View } from '../../../lib';
+import { render, Artboard, Text, View } from 'react-sketchapp';
 import chroma from 'chroma-js';
 
 // take a hex and give us a nice text color to put over it

--- a/examples/basic-setup/webpack.skpm.config.js
+++ b/examples/basic-setup/webpack.skpm.config.js
@@ -1,11 +1,13 @@
-module.exports = config => {
-  config.node = {
-    console: false,
-    global: false,
-    process: true,
-    __filename: 'mock',
-    __dirname: 'mock',
-    Buffer: false,
-    setImmediate: false,
-  };
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'), // FIXME: Should be able to do '../../', as that's a close simulation of an 'npm install' and import 'react-sketchapp'
+      },
+    };
+  }
 };

--- a/examples/basic-svg/webpack.skpm.config.js
+++ b/examples/basic-svg/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};

--- a/examples/colors/webpack.skpm.config.js
+++ b/examples/colors/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};

--- a/examples/emotion/webpack.skpm.config.js
+++ b/examples/emotion/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};

--- a/examples/form-validation/webpack.skpm.config.js
+++ b/examples/form-validation/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};

--- a/examples/foursquare-maps/webpack.skpm.config.js
+++ b/examples/foursquare-maps/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};

--- a/examples/glamorous/webpack.skpm.config.js
+++ b/examples/glamorous/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};

--- a/examples/profile-cards-graphql/webpack.skpm.config.js
+++ b/examples/profile-cards-graphql/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};

--- a/examples/profile-cards-primitives/webpack.skpm.config.js
+++ b/examples/profile-cards-primitives/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};

--- a/examples/profile-cards-react-with-styles/webpack.skpm.config.js
+++ b/examples/profile-cards-react-with-styles/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};

--- a/examples/profile-cards/webpack.skpm.config.js
+++ b/examples/profile-cards/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};

--- a/examples/react-router-prototyping/webpack.skpm.config.js
+++ b/examples/react-router-prototyping/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};

--- a/examples/styled-components/webpack.skpm.config.js
+++ b/examples/styled-components/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};

--- a/examples/styleguide/webpack.skpm.config.js
+++ b/examples/styleguide/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};

--- a/examples/symbols/webpack.skpm.config.js
+++ b/examples/symbols/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};

--- a/examples/timeline-airtable/webpack.skpm.config.js
+++ b/examples/timeline-airtable/webpack.skpm.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = (config) => {
+  if (process.env.LOCAL_DEV) {
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve.alias,
+        'react-sketchapp': path.resolve(__dirname, '../../lib/'),
+      },
+    };
+  }
+};


### PR DESCRIPTION
This PR creates integration tests for all the examples. The idea is to have a new tests folder that uses `skpm` `test-runner` and Webpack aliasing (to resolve dependencies like `chroma-js`, etc), with all of the dependencies of the examples in a single `package.json`.

This also introduces some better tooling for local development and testing, that should make it easy to setup pre-publish/pre-push hooks that can catch bugs. e.g. `LOCAL_DEV` environment variable to use the local source instead of `react-sketchapp` `npm` package for running `examples` locally, while keeping them individually git cloneable.

`e2e` examples are currently broken, so am doing some debugging to try to see what is causing the test runner crashes first. So far the `symbol.tsx` file seems problematic, maybe because of importing `yoga-layout-prebuilt`.

[WIP], will write more here later.

**Related issues**
> #363 