### PR TITLE
Integration tests for examples

### DIFF
--- a/__tests__/examples/package.json
+++ b/__tests__/examples/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "example-tests",
+  "version": "1.0.0",
+  "description": "",
+  "skpm": {
+    "main": "example-tests.sketchplugin",
+    "manifest": "src/manifest.json"
+  },
+  "scripts": {
+    "build": "../../node_modules/.bin/skpm-build",
+    "watch": "../../node_modules/.bin/skpm-build --watch",
+    "render": "../../node_modules/.bin/skpm-build --watch --run",
+    "render:once": "../../node_modules/.bin/skpm-build --run",
+    "postinstall": "npm run build && ../../node_modules/.bin/skpm-link"
+  },
+  "author": "Macintosh Helper <github@macintoshhelper.com>",
+  "license": "MIT",
+  "dependencies": {
+    "@emotion/core": "^10.0.28",
+    "@emotion/primitives": "^10.0.30",
+    "chroma-js": "^1.2.2",
+    "emotion-primitives": "^1.0.0-beta.0",
+    "ramda": "^0.27.0",
+    "react-primitives": "^0.8.1"
+  }
+}

--- a/__tests__/examples/src/main.js
+++ b/__tests__/examples/src/main.js
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import sketch from 'sketch';
+import { render, Document, Page } from 'react-sketchapp';
+
+import { Document as BasicSetup } from '../../../examples/basic-setup/src/my-command';
+import { Document as BasicSvg } from '../../../examples/basic-svg/src/my-command';
+import { Document as Colors } from '../../../examples/colors/src/main';
+import { App as Emotion } from '../../../examples/emotion/src/my-command';
+import { Page as FormValidation } from '../../../examples/form-validation/src/main';
+
+import formValidationData from '../../../examples/form-validation/src/data';
+
+const pages = [
+  {
+    component: BasicSetup,
+    name: 'Basic Setup',
+    data: {
+      colors: {
+        Haus: '#F3F4F4',
+        Night: '#333',
+        Sur: '#96DBE4',
+        'Sur Dark': '#24828F',
+        Peach: '#EFADA0',
+        'Peach Dark': '#E37059',
+        Pear: '#93DAAB',
+        'Pear Dark': '#2E854B',
+      },
+    },
+  },
+  {
+    component: BasicSvg,
+    name: 'Basic Svg',
+  },
+  {
+    component: Colors,
+    name: 'Colors',
+    data: {
+      colors: ['#01FFD8', '#C137E3', '#8702ED'],
+      steps: 50,
+    },
+  },
+  {
+    component: Emotion,
+    name: 'Emotion',
+  },
+  {
+    component: FormValidation,
+    name: 'Form Validation',
+    data: {
+      sessions: formValidationData,
+    },
+  },
+];
+
+const App = () => (
+  <Document>
+    {pages.map(({ name, component: Component, data }) => (
+      <Page key={name} name={name}>
+        <Component {...data} />
+      </Page>
+    ))}
+  </Document>
+);
+
+export default () => {
+  render(<App />, sketch.getSelectedDocument());
+};

--- a/__tests__/examples/src/manifest.json
+++ b/__tests__/examples/src/manifest.json
@@ -1,0 +1,17 @@
+{
+	"compatibleVersion": 3,
+	"bundleVersion": 1,
+	"commands": [
+		{
+			"name": "react-sketchapp: Example Tests",
+			"identifier": "main",
+			"script": "./main.js"
+		}
+	],
+	"menu": {
+		"isRoot": true,
+		"items": [
+			"main"
+		]
+	}
+}

--- a/__tests__/examples/webpack.skpm.config.js
+++ b/__tests__/examples/webpack.skpm.config.js
@@ -1,0 +1,24 @@
+const path = require('path');
+
+const aliasedModules = [
+  'chroma-js',
+  'ramda',
+  'react-primitives',
+  '@emotion/primitives',
+  '@emotion/core',
+];
+
+module.exports = (config) => {
+  config.resolve = {
+    ...config.resolve,
+    alias: {
+      ...config.resolve.alias,
+      'react-sketchapp': path.resolve(__dirname, '../../'),
+
+      ...aliasedModules.reduce((acc, mod) => {
+        acc[mod] = path.resolve(__dirname, `./node_modules/${mod}`);
+        return acc;
+      }, {}),
+    },
+  };
+};

--- a/examples/basic-setup/src/my-command.js
+++ b/examples/basic-setup/src/my-command.js
@@ -42,7 +42,7 @@ const Color = {
 
 Swatch.propTypes = Color;
 
-const Document = ({ colors }) => (
+export const Document = ({ colors }) => (
   <Artboard
     name="Swatches"
     style={{

--- a/examples/basic-svg/src/my-command.js
+++ b/examples/basic-svg/src/my-command.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { render, Artboard, Svg } from 'react-sketchapp';
 
-const Document = () => (
+export const Document = () => (
   <Artboard
     name="Sketch Logo"
     style={{

--- a/examples/colors/src/main.js
+++ b/examples/colors/src/main.js
@@ -14,7 +14,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const Document = ({ colors, steps }) => {
+export const Document = ({ colors, steps }) => {
   const color = chroma.scale(colors);
 
   return (

--- a/examples/emotion/package.json
+++ b/examples/emotion/package.json
@@ -18,7 +18,8 @@
     "@skpm/builder": "^0.4.3"
   },
   "dependencies": {
-    "emotion-primitives": "^1.0.0-beta.6",
+    "@emotion/core": "^10.0.28",
+    "@emotion/primitives": "^10.0.30",
     "react": "^16.4.1",
     "react-primitives": "^0.6.0",
     "react-sketchapp": "^3.0.0"

--- a/examples/emotion/src/my-command.js
+++ b/examples/emotion/src/my-command.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import emotion from 'emotion-primitives';
+import emotion from '@emotion/primitives';
 import { render } from 'react-sketchapp';
 
 const Container = emotion.View`
@@ -21,7 +21,7 @@ const Image = emotion.Image`
 
 const emotionLogo = 'https://avatars3.githubusercontent.com/u/31557565?s=400&v=4';
 
-class App extends React.Component {
+export class App extends React.Component {
   render() {
     return (
       <Container borderRadius="10px">

--- a/examples/form-validation/src/components/TextBox/index.sketch.js
+++ b/examples/form-validation/src/components/TextBox/index.sketch.js
@@ -2,13 +2,7 @@ import * as React from 'react';
 import { View, Text } from 'react-primitives';
 import styles from './style';
 
-type Props = {
-  label: string,
-  value: string,
-  children?: React$Element<any>,
-};
-
-const TextBox = ({ label, value, children }: Props) => (
+const TextBox = ({ label, value, children }) => (
   <View style={styles.formElement}>
     <Text style={styles.label}>{label}</Text>
     <View style={styles.textbox}>

--- a/examples/form-validation/src/main.js
+++ b/examples/form-validation/src/main.js
@@ -6,7 +6,7 @@ import DATA from './data';
 import Register from './components/Register';
 import Space from './components/Space';
 
-const Page = ({ sessions }) => (
+export const Page = ({ sessions }) => (
   <View>
     <Text style={typography.Heading}>Form Validation w/ DOM elements and React Primitives</Text>
     <View


### PR DESCRIPTION
`skpm-test` appears to be broken due to some `sketchtool` run issue (works fine importing the generated tests manually in Sketch GUI.

So for now, I'm creating a monolithic test example that is added to the test pipeline with `skpm-build __tests/examples/src/main.js` (pseudo-code, haven't tested the npm script yet).

This should make it easy to test all examples with a single command.